### PR TITLE
Use dev_dependencies for ansi_term

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ repository = "https://github.com/mackwic/colored"
 readme = "README.md"
 keywords = ["color", "string", "str", "terminal", "ansi_term"]
 
-[dependencies]
+[dev_dependencies]
 ansi_term = "0.7"


### PR DESCRIPTION
The dependencies section is for dependencies of the library,
not of its tests. Using this crate right now would unconditionally
pull in and build a copy of ansi_term, which isn't necessary.