### PR TITLE
Ignore coloring cues on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+# 1.2.0 (Mar 30, 2016)
+
+- Support the different formatting options, like padding and alignment
+
 # 1.1.0 (Mar 15, 2016)
 
 - Respect the CLICOLOR/CLICOLOR\_FORCE behavior. See [this specs](http://bixense.com/clicolors/)


### PR DESCRIPTION
Currently colored doesn't have true windows support. In the mean time to allow some cross platform usability without risking dumping ANSI codes to the terminal the colored string can ignore coloring on the windows platform.