### PR TITLE
Add new smart control module for finer control of coloring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ rust:
   - nightly
   - beta
   - stable
+
+matrix:
+  allow_failures:
+    - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "colored"
 description = "The most simple way to add colors in your terminal"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Thomas Wickham <mackwic@gmail.com>"]
 license = "MPL-2.0"
 homepage = "https://github.com/mackwic/colored"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ lazy_static = "0.1"
 
 [dev_dependencies]
 ansi_term = "0.7"
+rspec = "1.0.0-beta.2"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ For example, you can do this in your `Cargo.toml` to disable color in tests:
 test = ["colored/no-color"]
 ```
 
+You can use have even finer control by using the `colored::control::should_colorize` methods.
+
 ## Todo
 
 - **Windows console support**: this works only with ansi term. I plan to support

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ For example, you can do this in your `Cargo.toml` to disable color in tests:
 
 ```toml
 [features]
-# this effectively enable the feature `no-color` of colored when testing
+# this effectively enable the feature `no-color` of colored when testing with
+# `cargo test --feature test`
 test = ["colored/no-color"]
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Colored
 
 [![Build
-Status](https://travis-ci.org/mackwic/colored.svg?branch=master)](https://travis-ci.org/mackwic/colored)
+Status](https://travis-ci.org/mackwic/colored.svg?branch=master)](https://travis-ci.org/mackwic/colored) [![Crates.io](https://img.shields.io/crates/v/colored.svg?maxAge=2592000)](https://crates.io/crates/colored) [![Crates.io](https://img.shields.io/crates/l/colored.svg?maxAge=2592000)](https://github.com/mackwic/colored/blob/master/LICENSE)
 
 Coloring terminal so simple, you already know how to do it !
 
@@ -27,7 +27,7 @@ Add this in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-colored = "1.2"
+colored = "1.3"
 ```
 
 and add this to your `lib.rs` or `main.rs`:

--- a/src/control.rs
+++ b/src/control.rs
@@ -50,16 +50,18 @@ impl ShouldColorize {
             return manual_override;
         }
 
-        if Some(true) == self.clicolor_force {
-            return true;
+        if let Some(forced_value) = self.clicolor_force {
+            return forced_value;
+        }
+
+        if self.stdout_is_a_tty == false {
+            return false;
         }
 
         match (self.stdout_is_a_tty, self.clicolor) {
-            (_    , Some(true),        _)           => true,
-            (false, _,                 _)           => false,
-            (_,     Some(force_value), _)           => force_value,
-            (_,     _,                 Some(value)) => value,
-            _                                       => true
+            (false, _)           => false,
+            (_,     Some(value)) => value,
+            _                    => true
         }
     }
 
@@ -74,13 +76,18 @@ impl ShouldColorize {
 #[cfg(test)]
 mod specs {
     use super::*;
-    use rspec::context::{rdescribe};
+    use rspec::context::*;
+    use rspec;
     use std::env;
 
     #[test]
     fn clicolor_behavior() {
 
-        rdescribe("ShouldColorize", |ctx| {
+        use std::io;
+
+        let stdout = &mut io::stdout();
+        let mut formatter = rspec::formatter::Simple::new(stdout);
+        let mut runner = describe("ShouldColorize", |ctx| {
 
             ctx.describe("::normalize_env", |ctx| {
 
@@ -208,6 +215,8 @@ mod specs {
                 })
             });
         });
+        runner.add_event_handler(&mut formatter);
+        runner.run().unwrap();
     }
 }
 

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,0 +1,204 @@
+
+use lazy_static::*;
+use std::env;
+use std::default::Default;
+
+pub fn has_colors() -> bool {
+
+    let clicolor : &str = &env::var("CLICOLOR").unwrap_or(String::new());
+
+    match clicolor {
+        "0" => false,
+        _ => true
+    }
+}
+
+pub struct ShouldColorize {
+    clicolor: Option<bool>,
+    clicolor_force: Option<bool>,
+    stdout_is_a_tty: bool,
+    manual_override: Option<bool>
+}
+
+impl Default for ShouldColorize {
+    fn default() -> ShouldColorize {
+        ShouldColorize {
+            clicolor: None,
+            clicolor_force: None,
+            stdout_is_a_tty: true,
+            manual_override: None
+        }
+    }
+}
+
+impl ShouldColorize {
+    fn should_colorize(&self) -> bool {
+
+        match (self.stdout_is_a_tty, self.clicolor_force, self.clicolor) {
+            (_    , Some(true),        _)           => true,
+            (false, _,                 _)           => false,
+            (_,     Some(force_value), _)           => force_value,
+            (_,     _,                 Some(value)) => value,
+            _                                       => true
+        }
+    }
+}
+
+#[cfg(test)]
+mod specs {
+    use super::*;
+    use rspec::context::{rdescribe};
+
+
+    #[test]
+    fn clicolor_behavior() {
+
+        rdescribe("ShouldColorize::value", |ctx| {
+
+            ctx.describe("when only changing clicolors", |ctx| {
+                ctx.it("clicolor == false means no colors", || {
+                    let colorize_control = ShouldColorize {
+                        clicolor: Some(false),
+                        .. ShouldColorize::default()
+                    };
+                    false == colorize_control.should_colorize()
+                });
+
+                ctx.it("clicolor == true means colors !", || {
+                    let colorize_control = ShouldColorize {
+                        clicolor: Some(true),
+                        .. ShouldColorize::default()
+                    };
+                    true == colorize_control.should_colorize()
+                });
+
+                ctx.it("unset clicolors implies true", || {
+                    true == ShouldColorize::default().should_colorize()
+                });
+            });
+
+            ctx.describe("when using clicolor_force", |ctx| {
+
+                ctx.it("clicolor_force should force to true no matter clicolor", || {
+                    let colorize_control = ShouldColorize {
+                        clicolor: Some(false),
+                        clicolor_force: Some(true),
+                        .. ShouldColorize::default()
+                    };
+
+                    true == colorize_control.should_colorize()
+                });
+
+                ctx.it("clicolor_force should force to false no matter clicolor", || {
+                    let colorize_control = ShouldColorize {
+                        clicolor: Some(true),
+                        clicolor_force: Some(false),
+                        .. ShouldColorize::default()
+                    };
+
+                    false == colorize_control.should_colorize()
+                });
+            });
+            
+
+            ctx.describe("changing stdout_is_a_tty", |ctx| {
+
+                ctx.it("should not colorize when stdout_is_a_tty is false", || {
+
+                    let colorize_control = ShouldColorize {
+                        clicolor: Some(true),
+                        stdout_is_a_tty: false,
+                        .. ShouldColorize::default()
+                    };
+
+                    false == colorize_control.should_colorize()
+                });
+
+                ctx.it("it should colorize if clicolor_force is true and stdout_is_a_tty false", || {
+
+                    let colorize_control = ShouldColorize {
+                        clicolor: Some(true),
+                        stdout_is_a_tty: false,
+                        clicolor_force: Some(true),
+                        .. ShouldColorize::default()
+                    };
+
+                    true == colorize_control.should_colorize()
+                })
+            });
+        });
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    pub use std::env;
+    pub use std::thread;
+    pub use std::time;
+
+    macro_rules! with_env (
+        (empty, $body:block)                                => (with_env!(clicolor:"", clicolor_force:"", $body));
+        (clicolor: $clicolor:expr, clicolor_force: $clicolor_force:expr, $body:block) => {{
+
+            let old_clicolor = env::var_os("CLICOLOR").unwrap_or("".into());
+            let old_clicolor_force = env::var_os("CLICOLOR_FORCE").unwrap_or("".into());
+
+            env::set_var("CLICOLOR", $clicolor);
+            assert!(Ok($clicolor.into()) == env::var("CLICOLOR"),
+                    "setting the env var `clicolor` failed for some reason. Please re-run the test");
+
+            env::set_var("CLICOLOR_FORCE", $clicolor_force);
+            assert!(Ok($clicolor_force.into()) == env::var("CLICOLOR_FORCE"),
+                    "setting the env variable `clicolor_force` failed for some reason. Please re-run the test");
+
+            $body;
+
+            env::set_var("CLICOLOR", old_clicolor.clone());
+            assert!(Some(old_clicolor) == env::var_os("CLICOLOR"),
+                    "setting back the env var `clicolor` failed for some reason. Please re-run the test");
+
+            env::set_var("CLICOLOR_FORCE", old_clicolor_force.clone());
+            assert!(Some(old_clicolor_force) == env::var_os("CLICOLOR_FORCE"),
+                    "setting back the env var `clicolor_force` failed for some reason. Please re-run the test");
+        }};
+        (clicolor_force: $clicolor_force:expr, $body:block) => (with_env!(clicolor:"", clicolor_force: $clicolor_force, $body));
+        (clicolor: $clicolor:expr, $body:block)             => (with_env!(clicolor: $clicolor, clicolor_force: "", $body));
+    );
+
+    #[test]
+    fn it_expose_the_current_state_of_colors() {
+        has_colors();
+    }
+
+    #[test]
+    fn it_is_on_by_default() {
+        with_env!(empty, {
+            assert_eq!(true, has_colors());
+        });
+    }
+
+    #[test]
+    fn it_is_off_when_env_clicolor_is_zero() {
+        with_env!(clicolor: "0", {
+            assert_eq!(false, has_colors());
+        });
+    }
+
+    #[test]
+    fn it_is_on_when_env_clicolor_is_one_or_anything() {
+        with_env!(clicolor: "1", {
+            assert_eq!(true, has_colors());
+        });
+        with_env!(clicolor: "2", {
+            assert_eq!(true, has_colors());
+        });
+        with_env!(clicolor: "a", {
+            assert_eq!(true, has_colors());
+        });
+        with_env!(clicolor: "plop", {
+            assert_eq!(true, has_colors());
+        });
+    }
+}

--- a/src/control.rs
+++ b/src/control.rs
@@ -8,6 +8,10 @@ pub struct ShouldColorize {
     manual_override: Option<bool>
 }
 
+lazy_static! {
+    pub static ref SHOULD_COLORIZE : ShouldColorize = ShouldColorize::from_env();
+}
+
 impl Default for ShouldColorize {
     fn default() -> ShouldColorize {
         ShouldColorize {
@@ -54,6 +58,8 @@ impl ShouldColorize {
     pub fn unset_override(&mut self) {
         self.manual_override = None;
     }
+
+    /* private */
 
     fn normalize_env(env_res: Result<String, env::VarError>) -> Option<bool> {
         match env_res {

--- a/src/control.rs
+++ b/src/control.rs
@@ -20,7 +20,7 @@ impl Default for ShouldColorize {
 
 impl ShouldColorize {
 
-    fn from_env() -> Self {
+    pub fn from_env() -> Self {
         use std::io;
 
         ShouldColorize {
@@ -45,6 +45,14 @@ impl ShouldColorize {
         }
 
         return true;
+    }
+
+    pub fn set_override(&mut self, override_colorize: bool) {
+        self.manual_override = Some(override_colorize);
+    }
+
+    pub fn unset_override(&mut self) {
+        self.manual_override = None;
     }
 
     fn normalize_env(env_res: Result<String, env::VarError>) -> Option<bool> {
@@ -167,6 +175,35 @@ mod specs {
 
                     false == colorize_control.should_colorize()
                 })
+            });
+
+            ctx.describe("::set_override", |ctx| {
+                ctx.it("should exists", || {
+                    let mut colorize_control = ShouldColorize::default();
+                    colorize_control.set_override(true);
+                });
+
+                ctx.it("set the manual_override property", || {
+                    let mut colorize_control = ShouldColorize::default();
+                    colorize_control.set_override(true);
+                    assert_eq!(Some(true), colorize_control.manual_override);
+                    colorize_control.set_override(false);
+                    assert_eq!(Some(false), colorize_control.manual_override);
+                });
+            });
+
+            ctx.describe("::unset_override", |ctx| {
+                ctx.it("should exists", || {
+                    let mut colorize_control = ShouldColorize::default();
+                    colorize_control.unset_override();
+                });
+
+                ctx.it("unset the manual_override property", || {
+                    let mut colorize_control = ShouldColorize::default();
+                    colorize_control.set_override(true);
+                    colorize_control.unset_override();
+                    assert_eq!(None, colorize_control.manual_override);
+                });
             });
         });
         runner.add_event_handler(&mut formatter);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,12 @@
-#![allow(unused_imports,dead_code)]
+#![allow(unused_imports,dead_code,unused_parens)]
 
 #[macro_use]
 extern crate lazy_static;
 
+#[cfg(test)]
+extern crate rspec;
+
+mod control;
 mod color;
 mod style;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ extern crate lazy_static;
 #[cfg(test)]
 extern crate rspec;
 
-mod control;
+pub mod control;
 mod color;
 mod style;
 
@@ -66,19 +66,9 @@ impl ColoredString {
 
     #[cfg(not(feature = "no-color"))]
     fn has_colors(&self) -> bool {
-        use std::env::var_os;
-        use std::ffi::OsString;
-        fn is_good(var: Option<OsString>) -> bool {
-            var.is_none() || var != Some("0".into())
-        }
-        lazy_static! {
-            static ref COLOR_STATE : bool = (
-                (var_os("CLICOLOR_FORCE").or(Some("0".into()))
-                 != Some("0".into()))
-                 || is_good(var_os("CLICOLOR"))
-            );
-        }
-        *COLOR_STATE
+        use control;
+
+        control::SHOULD_COLORIZE.should_colorize()
     }
 
     #[cfg(feature = "no-color")]


### PR DESCRIPTION
TODO:
- [x] move the logic in its own module
- [x] ~~detect if stdout_is_a_tty~~ (removed: not smart enough and carry a dependance to libc)
- [ ] detect windows platform
- [ ] try to see if we can detect cygwin / mingw / cmder etc... (opt) 
- [x] manual override (via global toggle flag)
- [ ] manual override for block

Will make colored v2
