### PR TITLE
Upgraded lazy_static to 0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.5.1 (May 9, 2017)
+
+- Update lazy_static to 0.2.
 
 # 1.5.0 (May 1, 2017)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "colored"
 description = "The most simple way to add colors in your terminal"
-version = "1.6.0"
+version = "1.5.1"
 authors = ["Thomas Wickham <mackwic@gmail.com>"]
 license = "MPL-2.0"
 homepage = "https://github.com/mackwic/colored"
@@ -14,7 +14,7 @@ keywords = ["color", "string", "term", "ansi_term", "term-painter"]
 no-color = []
 
 [dependencies]
-lazy_static = "0.2"
+lazy_static = "^0.2"
 
 [dev_dependencies]
 ansi_term = "^0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "colored"
 description = "The most simple way to add colors in your terminal"
-version = "1.5.0"
+version = "1.6.0"
 authors = ["Thomas Wickham <mackwic@gmail.com>"]
 license = "MPL-2.0"
 homepage = "https://github.com/mackwic/colored"
@@ -14,7 +14,7 @@ keywords = ["color", "string", "term", "ansi_term", "term-painter"]
 no-color = []
 
 [dependencies]
-lazy_static = "0.1"
+lazy_static = "0.2"
 
 [dev_dependencies]
 ansi_term = "^0.9"

--- a/README.md
+++ b/README.md
@@ -139,4 +139,4 @@ In non legal terms it means that:
 
 - Thomas Wickham: [@mackwic](https://github.com/mackwic)
 - Corey "See More" Richardson: [@cmr](https://github.com/cmr)
-
+- Iban Eguia: [@Razican](https://github.com/Razican)


### PR DESCRIPTION
Using `lazy_static` 0.1 was giving me some issues. Can we just update it? All tests pass.