### PR TITLE
Respect the NO_COLOR standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,4 @@ In non legal terms it means that:
 - Alexis "Horgix" Chotard: [@horgix](https://github.com/horgix)
 - Keith Yeung: [@KiChjang](https://github.com/KiChjang)
 - Kyle Galloway: [@kylegalloway](https://github.com/kylegalloway)
+- Luke Hsiao: [@lukehsiao](https://github.com/lukehsiao)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ and add this to your `lib.rs` or `main.rs`:
 
 - Safe rust, easy to use, minimal dependencies, complete test suite
 - Respect the `CLICOLOR`/`CLICOLOR_FORCE` behavior (see [the specs](http://bixense.com/clicolors/))
+- Respect the `NO_COLOR` behavior (see [the specs](https://no-color.org/))
 - Works on Linux, MacOS, and Windows (Powershell)
 
 #### Colors:


### PR DESCRIPTION
Similar to the behavior for `CLICOLOR`/`CLICOLOR_FORCE`, this adds support
for the `NO_COLOR` spec (https://no-color.org/). The `NO_COLOR` spec is also
implemented by Homebrew and `npm`. 

See #2. 