### PR TITLE
Remove unnecessary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ colored = "1.7"
 and add this to your `lib.rs` or `main.rs`:
 
 ```rust
+    extern crate colored; // not needed in Rust 2018
+    
     use colored::*;
 
     // test the example with `cargo run --example most_simple`

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ colored = "1.7"
 and add this to your `lib.rs` or `main.rs`:
 
 ```rust
-    extern crate colored;
-
     use colored::*;
 
     // test the example with `cargo run --example most_simple`


### PR DESCRIPTION
Now you can just write `use colored::*;` without using an extern keyword. It's much easier!)