### PR TITLE
Win10 color

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ no-color = []
 
 [dependencies]
 lazy_static = "1.2.0"
+winconsole = "0.10.0"
 
 [dev_dependencies]
 ansi_term = "^0.9"

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ colored = "1.7"
 and add this to your `lib.rs` or `main.rs`:
 
 ```rust
-    extern crate colored;
-
+    extern crate colored; // not needed in Rust 2018
+    
     use colored::*;
 
     // test the example with `cargo run --example most_simple`

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ colored = "1.7"
 and add this to your `lib.rs` or `main.rs`:
 
 ```rust
-    extern crate colored; // not needed in Rust 2018
-    
+    extern crate colored;
+
     use colored::*;
 
     // test the example with `cargo run --example most_simple`

--- a/src/control.rs
+++ b/src/control.rs
@@ -3,20 +3,25 @@
 use std::default::Default;
 use std::env;
 use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(windows)]
 use winconsole::{console, errors::WinResult};
 
 /// Sets a flag to the console to use a virtual terminal environment.
 /// This is primarily used for Windows 10 environments which will not correctly colorize the outputs based on ansi escape codes.
 ///
+/// # Notes
+/// > Only available to `Windows` build targets.
+///
 /// # Example
 /// ```rust
 /// use colored::*;
 /// control::set_virtual_terminal(false);
-/// println!("{}", "bright cyan".bright_cyan());	// will print '[96mbright cyan[0m' on windows 10
+/// println!("{}", "bright cyan".bright_cyan());	// will print '[96mbright cyan[0m' on windows 10
 ///
 /// control::set_virtual_terminal(true);
 /// println!("{}", "bright cyan".bright_cyan());	// will print correctly
 /// ```
+#[cfg(windows)]
 pub fn set_virtual_terminal(use_virtual: bool) -> WinResult<()> {
 	let mut mode = console::get_output_mode()?;
 	mode.VirtualTerminalProcessing = use_virtual;

--- a/src/control.rs
+++ b/src/control.rs
@@ -3,156 +3,176 @@
 use std::default::Default;
 use std::env;
 use std::sync::atomic::{AtomicBool, Ordering};
+use winconsole::{console, errors::WinResult};
+
+/// Sets a flag to the console to use a virtual terminal environment.
+/// This is primarily used for Windows 10 environments which will not correctly colorize the outputs based on ansi escape codes.
+///
+/// # Example
+/// ```rust
+/// use colored::*;
+/// control::set_virtual_terminal(false);
+/// println!("{}", "bright green".bright_green());	// will print '[96mbright green[0m' on windows 10
+///
+/// control::set_virtual_terminal(true);
+/// println!("{}", "bright green".bright_green());	// will print correctly
+/// ```
+pub fn set_virtual_terminal(use_virtual: bool) -> WinResult<()> {
+	let mut mode = console::get_output_mode()?;
+	mode.VirtualTerminalProcessing = use_virtual;
+	console::set_output_mode(mode)?;
+	Ok(())
+}
 
 pub struct ShouldColorize {
-    clicolor: Option<bool>,
-    clicolor_force: Option<bool>,
-    // XXX we can't use Option<Atomic> because we can't use &mut references to ShouldColorize
-    has_manual_override: AtomicBool,
-    manual_override: AtomicBool,
+	clicolor: Option<bool>,
+	clicolor_force: Option<bool>,
+	// XXX we can't use Option<Atomic> because we can't use &mut references to ShouldColorize
+	has_manual_override: AtomicBool,
+	manual_override: AtomicBool,
 }
 
 /// Use this to force colored to ignore the environment and always/never colorize
 /// See example/control.rs
 pub fn set_override(override_colorize: bool) {
-    SHOULD_COLORIZE.set_override(override_colorize)
+	SHOULD_COLORIZE.set_override(override_colorize)
 }
 
 /// Remove the manual override and let the environment decide if it's ok to colorize
 /// See example/control.rs
 pub fn unset_override() {
-    SHOULD_COLORIZE.unset_override()
+	SHOULD_COLORIZE.unset_override()
 }
 
 lazy_static! {
-    pub static ref SHOULD_COLORIZE: ShouldColorize = ShouldColorize::from_env();
+	pub static ref SHOULD_COLORIZE: ShouldColorize = ShouldColorize::from_env();
 }
 
 impl Default for ShouldColorize {
-    fn default() -> ShouldColorize {
-        ShouldColorize {
-            clicolor: None,
-            clicolor_force: None,
-            has_manual_override: AtomicBool::new(false),
-            manual_override: AtomicBool::new(false),
-        }
-    }
+	fn default() -> ShouldColorize {
+		ShouldColorize {
+			clicolor: None,
+			clicolor_force: None,
+			has_manual_override: AtomicBool::new(false),
+			manual_override: AtomicBool::new(false),
+		}
+	}
 }
 
 impl ShouldColorize {
-    /// Reads environment variables to determine whether colorization should
-    /// be used or not. `CLICOLOR_FORCE` takes highest priority, followed by
-    /// `NO_COLOR`, followed by `CLICOLOR`. In the absence of manual overrides,
-    /// which take precedence over all environment variables, the priority
-    /// of these variables can be expressed as follows.
-    ///
-    /// `NO_COLOR`  | `CLICOLOR`          | `CLICOLOR_FORCE`   | colorize?
-    /// :---------  | :---------          | :---------------   | :--------
-    /// unset       | unset               | unset              | true (default)
-    /// unset       | `!= 0`              | unset              | true
-    /// unset       | `== 0`              | unset              | false
-    /// set         | unset/`== 0`/`!= 0` | unset              | false
-    /// set/unset   | unset/`== 0`/`!= 0` | `== 0`             | false
-    /// set/unset   | unset/`== 0`/`!= 0` | `!= 0`             | true
-    pub fn from_env() -> Self {
-        use std::io;
+	/// Reads environment variables to determine whether colorization should
+	/// be used or not. `CLICOLOR_FORCE` takes highest priority, followed by
+	/// `NO_COLOR`, followed by `CLICOLOR`. In the absence of manual overrides,
+	/// which take precedence over all environment variables, the priority
+	/// of these variables can be expressed as follows.
+	///
+	/// `NO_COLOR`  | `CLICOLOR`          | `CLICOLOR_FORCE`   | colorize?
+	/// :---------  | :---------          | :---------------   | :--------
+	/// unset       | unset               | unset              | true (default)
+	/// unset       | `!= 0`              | unset              | true
+	/// unset       | `== 0`              | unset              | false
+	/// set         | unset/`== 0`/`!= 0` | unset              | false
+	/// set/unset   | unset/`== 0`/`!= 0` | `== 0`             | false
+	/// set/unset   | unset/`== 0`/`!= 0` | `!= 0`             | true
+	pub fn from_env() -> Self {
+		use std::io;
 
-        ShouldColorize {
-            clicolor: ShouldColorize::normalize_env(env::var("CLICOLOR")),
-            clicolor_force: ShouldColorize::resolve_clicolor_force(
-                env::var("NO_COLOR"),
-                env::var("CLICOLOR_FORCE"),
-            ),
-            ..ShouldColorize::default()
-        }
-    }
+		ShouldColorize {
+			clicolor: ShouldColorize::normalize_env(env::var("CLICOLOR")),
+			clicolor_force: ShouldColorize::resolve_clicolor_force(
+				env::var("NO_COLOR"),
+				env::var("CLICOLOR_FORCE"),
+			),
+			..ShouldColorize::default()
+		}
+	}
 
-    pub fn should_colorize(&self) -> bool {
-        if self.has_manual_override.load(Ordering::Relaxed) {
-            return self.manual_override.load(Ordering::Relaxed);
-        }
+	pub fn should_colorize(&self) -> bool {
+		if self.has_manual_override.load(Ordering::Relaxed) {
+			return self.manual_override.load(Ordering::Relaxed);
+		}
 
-        if let Some(forced_value) = self.clicolor_force {
-            return forced_value;
-        }
+		if let Some(forced_value) = self.clicolor_force {
+			return forced_value;
+		}
 
-        if let Some(value) = self.clicolor {
-            return value;
-        }
+		if let Some(value) = self.clicolor {
+			return value;
+		}
 
-        true
-    }
+		true
+	}
 
-    pub fn set_override(&self, override_colorize: bool) {
-        self.has_manual_override.store(true, Ordering::Relaxed);
-        self.manual_override
-            .store(override_colorize, Ordering::Relaxed);
-    }
+	pub fn set_override(&self, override_colorize: bool) {
+		self.has_manual_override.store(true, Ordering::Relaxed);
+		self.manual_override
+			.store(override_colorize, Ordering::Relaxed);
+	}
 
-    pub fn unset_override(&self) {
-        self.has_manual_override.store(false, Ordering::Relaxed);
-    }
+	pub fn unset_override(&self) {
+		self.has_manual_override.store(false, Ordering::Relaxed);
+	}
 
-    /* private */
+	/* private */
 
-    fn normalize_env(env_res: Result<String, env::VarError>) -> Option<bool> {
-        match env_res {
-            Ok(string) => Some(string != "0"),
-            Err(_) => None,
-        }
-    }
+	fn normalize_env(env_res: Result<String, env::VarError>) -> Option<bool> {
+		match env_res {
+			Ok(string) => Some(string != "0"),
+			Err(_) => None,
+		}
+	}
 
-    fn resolve_clicolor_force(
-        no_color: Result<String, env::VarError>,
-        clicolor_force: Result<String, env::VarError>,
-    ) -> Option<bool> {
-        match (
-            ShouldColorize::normalize_env(no_color),
-            ShouldColorize::normalize_env(clicolor_force),
-        ) {
-            (_, Some(b)) => Some(b),
-            (Some(_), None) => Some(false),
-            (None, None) => None,
-        }
-    }
+	fn resolve_clicolor_force(
+		no_color: Result<String, env::VarError>,
+		clicolor_force: Result<String, env::VarError>,
+	) -> Option<bool> {
+		match (
+			ShouldColorize::normalize_env(no_color),
+			ShouldColorize::normalize_env(clicolor_force),
+		) {
+			(_, Some(b)) => Some(b),
+			(Some(_), None) => Some(false),
+			(None, None) => None,
+		}
+	}
 }
 
 #[cfg(test)]
 mod specs {
-    use super::*;
-    use rspec;
-    use rspec::context::*;
-    use std::env;
+	use super::*;
+	use rspec;
+	use rspec::context::*;
+	use std::env;
 
-    #[test]
-    fn clicolor_behavior() {
-        use std::io;
+	#[test]
+	fn clicolor_behavior() {
+		use std::io;
 
-        let stdout = &mut io::stdout();
-        let mut formatter = rspec::formatter::Simple::new(stdout);
-        let mut runner = describe("ShouldColorize", |ctx| {
-            ctx.describe("::normalize_env", |ctx| {
-                ctx.it("should return None if error", || {
-                    assert_eq!(
-                        None,
-                        ShouldColorize::normalize_env(Err(env::VarError::NotPresent))
-                    );
-                    assert_eq!(
-                        None,
-                        ShouldColorize::normalize_env(Err(env::VarError::NotUnicode("".into())))
-                    )
-                });
+		let stdout = &mut io::stdout();
+		let mut formatter = rspec::formatter::Simple::new(stdout);
+		let mut runner = describe("ShouldColorize", |ctx| {
+			ctx.describe("::normalize_env", |ctx| {
+				ctx.it("should return None if error", || {
+					assert_eq!(
+						None,
+						ShouldColorize::normalize_env(Err(env::VarError::NotPresent))
+					);
+					assert_eq!(
+						None,
+						ShouldColorize::normalize_env(Err(env::VarError::NotUnicode("".into())))
+					)
+				});
 
-                ctx.it("should return Some(true) if != 0", || {
-                    Some(true) == ShouldColorize::normalize_env(Ok(String::from("1")))
-                });
+				ctx.it("should return Some(true) if != 0", || {
+					Some(true) == ShouldColorize::normalize_env(Ok(String::from("1")))
+				});
 
-                ctx.it("should return Some(false) if == 0", || {
-                    Some(false) == ShouldColorize::normalize_env(Ok(String::from("0")))
-                });
-            });
+				ctx.it("should return Some(false) if == 0", || {
+					Some(false) == ShouldColorize::normalize_env(Ok(String::from("0")))
+				});
+			});
 
-            ctx.describe("::resolve_clicolor_force", |ctx| {
+			ctx.describe("::resolve_clicolor_force", |ctx| {
                 ctx.it(
                     "should return None if neither NO_COLOR nor CLICOLOR_FORCE are set",
                     || {
@@ -221,67 +241,67 @@ mod specs {
                 );
             });
 
-            ctx.describe("constructors", |ctx| {
-                ctx.it("should have a default constructor", || {
-                    ShouldColorize::default();
-                });
+			ctx.describe("constructors", |ctx| {
+				ctx.it("should have a default constructor", || {
+					ShouldColorize::default();
+				});
 
-                ctx.it("should have an environment constructor", || {
-                    ShouldColorize::from_env();
-                });
-            });
+				ctx.it("should have an environment constructor", || {
+					ShouldColorize::from_env();
+				});
+			});
 
-            ctx.describe("when only changing clicolors", |ctx| {
-                ctx.it("clicolor == false means no colors", || {
-                    let colorize_control = ShouldColorize {
-                        clicolor: Some(false),
-                        ..ShouldColorize::default()
-                    };
-                    false == colorize_control.should_colorize()
-                });
+			ctx.describe("when only changing clicolors", |ctx| {
+				ctx.it("clicolor == false means no colors", || {
+					let colorize_control = ShouldColorize {
+						clicolor: Some(false),
+						..ShouldColorize::default()
+					};
+					false == colorize_control.should_colorize()
+				});
 
-                ctx.it("clicolor == true means colors !", || {
-                    let colorize_control = ShouldColorize {
-                        clicolor: Some(true),
-                        ..ShouldColorize::default()
-                    };
-                    true == colorize_control.should_colorize()
-                });
+				ctx.it("clicolor == true means colors !", || {
+					let colorize_control = ShouldColorize {
+						clicolor: Some(true),
+						..ShouldColorize::default()
+					};
+					true == colorize_control.should_colorize()
+				});
 
-                ctx.it("unset clicolors implies true", || {
-                    true == ShouldColorize::default().should_colorize()
-                });
-            });
+				ctx.it("unset clicolors implies true", || {
+					true == ShouldColorize::default().should_colorize()
+				});
+			});
 
-            ctx.describe("when using clicolor_force", |ctx| {
-                ctx.it(
-                    "clicolor_force should force to true no matter clicolor",
-                    || {
-                        let colorize_control = ShouldColorize {
-                            clicolor: Some(false),
-                            clicolor_force: Some(true),
-                            ..ShouldColorize::default()
-                        };
+			ctx.describe("when using clicolor_force", |ctx| {
+				ctx.it(
+					"clicolor_force should force to true no matter clicolor",
+					|| {
+						let colorize_control = ShouldColorize {
+							clicolor: Some(false),
+							clicolor_force: Some(true),
+							..ShouldColorize::default()
+						};
 
-                        true == colorize_control.should_colorize()
-                    },
-                );
+						true == colorize_control.should_colorize()
+					},
+				);
 
-                ctx.it(
-                    "clicolor_force should force to false no matter clicolor",
-                    || {
-                        let colorize_control = ShouldColorize {
-                            clicolor: Some(true),
-                            clicolor_force: Some(false),
-                            ..ShouldColorize::default()
-                        };
+				ctx.it(
+					"clicolor_force should force to false no matter clicolor",
+					|| {
+						let colorize_control = ShouldColorize {
+							clicolor: Some(true),
+							clicolor_force: Some(false),
+							..ShouldColorize::default()
+						};
 
-                        false == colorize_control.should_colorize()
-                    },
-                );
-            });
+						false == colorize_control.should_colorize()
+					},
+				);
+			});
 
-            ctx.describe("using a manual override", |ctx| {
+			ctx.describe("using a manual override", |ctx| {
                 ctx.it("shoud colorize if manual_override is true, but clicolor is false and clicolor_force also false", || {
                     let colorize_control = ShouldColorize {
                         clicolor: Some(false),
@@ -307,53 +327,53 @@ mod specs {
                 })
             });
 
-            ctx.describe("::set_override", |ctx| {
-                ctx.it("should exists", || {
-                    let colorize_control = ShouldColorize::default();
-                    colorize_control.set_override(true);
-                });
+			ctx.describe("::set_override", |ctx| {
+				ctx.it("should exists", || {
+					let colorize_control = ShouldColorize::default();
+					colorize_control.set_override(true);
+				});
 
-                ctx.it("set the manual_override property", || {
-                    let colorize_control = ShouldColorize::default();
-                    colorize_control.set_override(true);
-                    {
-                        assert_eq!(
-                            true,
-                            colorize_control.has_manual_override.load(Ordering::Relaxed)
-                        );
-                        let val = colorize_control.manual_override.load(Ordering::Relaxed);
-                        assert_eq!(true, val);
-                    }
-                    colorize_control.set_override(false);
-                    {
-                        assert_eq!(
-                            true,
-                            colorize_control.has_manual_override.load(Ordering::Relaxed)
-                        );
-                        let val = colorize_control.manual_override.load(Ordering::Relaxed);
-                        assert_eq!(false, val);
-                    }
-                });
-            });
+				ctx.it("set the manual_override property", || {
+					let colorize_control = ShouldColorize::default();
+					colorize_control.set_override(true);
+					{
+						assert_eq!(
+							true,
+							colorize_control.has_manual_override.load(Ordering::Relaxed)
+						);
+						let val = colorize_control.manual_override.load(Ordering::Relaxed);
+						assert_eq!(true, val);
+					}
+					colorize_control.set_override(false);
+					{
+						assert_eq!(
+							true,
+							colorize_control.has_manual_override.load(Ordering::Relaxed)
+						);
+						let val = colorize_control.manual_override.load(Ordering::Relaxed);
+						assert_eq!(false, val);
+					}
+				});
+			});
 
-            ctx.describe("::unset_override", |ctx| {
-                ctx.it("should exists", || {
-                    let colorize_control = ShouldColorize::default();
-                    colorize_control.unset_override();
-                });
+			ctx.describe("::unset_override", |ctx| {
+				ctx.it("should exists", || {
+					let colorize_control = ShouldColorize::default();
+					colorize_control.unset_override();
+				});
 
-                ctx.it("unset the manual_override property", || {
-                    let colorize_control = ShouldColorize::default();
-                    colorize_control.set_override(true);
-                    colorize_control.unset_override();
-                    assert_eq!(
-                        false,
-                        colorize_control.has_manual_override.load(Ordering::Relaxed)
-                    );
-                });
-            });
-        });
-        runner.add_event_handler(&mut formatter);
-        runner.run().unwrap();
-    }
+				ctx.it("unset the manual_override property", || {
+					let colorize_control = ShouldColorize::default();
+					colorize_control.set_override(true);
+					colorize_control.unset_override();
+					assert_eq!(
+						false,
+						colorize_control.has_manual_override.load(Ordering::Relaxed)
+					);
+				});
+			});
+		});
+		runner.add_event_handler(&mut formatter);
+		runner.run().unwrap();
+	}
 }

--- a/src/control.rs
+++ b/src/control.rs
@@ -12,10 +12,10 @@ use winconsole::{console, errors::WinResult};
 /// ```rust
 /// use colored::*;
 /// control::set_virtual_terminal(false);
-/// println!("{}", "bright green".bright_green());	// will print '[96mbright green[0m' on windows 10
+/// println!("{}", "bright cyan".bright_cyan());	// will print '[96mbright cyan[0m' on windows 10
 ///
 /// control::set_virtual_terminal(true);
-/// println!("{}", "bright green".bright_green());	// will print correctly
+/// println!("{}", "bright cyan".bright_cyan());	// will print correctly
 /// ```
 pub fn set_virtual_terminal(use_virtual: bool) -> WinResult<()> {
 	let mut mode = console::get_output_mode()?;

--- a/src/control.rs
+++ b/src/control.rs
@@ -30,154 +30,154 @@ pub fn set_virtual_terminal(use_virtual: bool) -> WinResult<()> {
 }
 
 pub struct ShouldColorize {
-	clicolor: Option<bool>,
-	clicolor_force: Option<bool>,
-	// XXX we can't use Option<Atomic> because we can't use &mut references to ShouldColorize
-	has_manual_override: AtomicBool,
-	manual_override: AtomicBool,
+    clicolor: Option<bool>,
+    clicolor_force: Option<bool>,
+    // XXX we can't use Option<Atomic> because we can't use &mut references to ShouldColorize
+    has_manual_override: AtomicBool,
+    manual_override: AtomicBool,
 }
 
 /// Use this to force colored to ignore the environment and always/never colorize
 /// See example/control.rs
 pub fn set_override(override_colorize: bool) {
-	SHOULD_COLORIZE.set_override(override_colorize)
+    SHOULD_COLORIZE.set_override(override_colorize)
 }
 
 /// Remove the manual override and let the environment decide if it's ok to colorize
 /// See example/control.rs
 pub fn unset_override() {
-	SHOULD_COLORIZE.unset_override()
+    SHOULD_COLORIZE.unset_override()
 }
 
 lazy_static! {
-	pub static ref SHOULD_COLORIZE: ShouldColorize = ShouldColorize::from_env();
+    pub static ref SHOULD_COLORIZE: ShouldColorize = ShouldColorize::from_env();
 }
 
 impl Default for ShouldColorize {
-	fn default() -> ShouldColorize {
-		ShouldColorize {
-			clicolor: None,
-			clicolor_force: None,
-			has_manual_override: AtomicBool::new(false),
-			manual_override: AtomicBool::new(false),
-		}
-	}
+    fn default() -> ShouldColorize {
+        ShouldColorize {
+            clicolor: None,
+            clicolor_force: None,
+            has_manual_override: AtomicBool::new(false),
+            manual_override: AtomicBool::new(false),
+        }
+    }
 }
 
 impl ShouldColorize {
-	/// Reads environment variables to determine whether colorization should
-	/// be used or not. `CLICOLOR_FORCE` takes highest priority, followed by
-	/// `NO_COLOR`, followed by `CLICOLOR`. In the absence of manual overrides,
-	/// which take precedence over all environment variables, the priority
-	/// of these variables can be expressed as follows.
-	///
-	/// `NO_COLOR`  | `CLICOLOR`          | `CLICOLOR_FORCE`   | colorize?
-	/// :---------  | :---------          | :---------------   | :--------
-	/// unset       | unset               | unset              | true (default)
-	/// unset       | `!= 0`              | unset              | true
-	/// unset       | `== 0`              | unset              | false
-	/// set         | unset/`== 0`/`!= 0` | unset              | false
-	/// set/unset   | unset/`== 0`/`!= 0` | `== 0`             | false
-	/// set/unset   | unset/`== 0`/`!= 0` | `!= 0`             | true
-	pub fn from_env() -> Self {
-		use std::io;
+    /// Reads environment variables to determine whether colorization should
+    /// be used or not. `CLICOLOR_FORCE` takes highest priority, followed by
+    /// `NO_COLOR`, followed by `CLICOLOR`. In the absence of manual overrides,
+    /// which take precedence over all environment variables, the priority
+    /// of these variables can be expressed as follows.
+    ///
+    /// `NO_COLOR`  | `CLICOLOR`          | `CLICOLOR_FORCE`   | colorize?
+    /// :---------  | :---------          | :---------------   | :--------
+    /// unset       | unset               | unset              | true (default)
+    /// unset       | `!= 0`              | unset              | true
+    /// unset       | `== 0`              | unset              | false
+    /// set         | unset/`== 0`/`!= 0` | unset              | false
+    /// set/unset   | unset/`== 0`/`!= 0` | `== 0`             | false
+    /// set/unset   | unset/`== 0`/`!= 0` | `!= 0`             | true
+    pub fn from_env() -> Self {
+        use std::io;
 
-		ShouldColorize {
-			clicolor: ShouldColorize::normalize_env(env::var("CLICOLOR")),
-			clicolor_force: ShouldColorize::resolve_clicolor_force(
-				env::var("NO_COLOR"),
-				env::var("CLICOLOR_FORCE"),
-			),
-			..ShouldColorize::default()
-		}
-	}
+        ShouldColorize {
+            clicolor: ShouldColorize::normalize_env(env::var("CLICOLOR")),
+            clicolor_force: ShouldColorize::resolve_clicolor_force(
+                env::var("NO_COLOR"),
+                env::var("CLICOLOR_FORCE"),
+            ),
+            ..ShouldColorize::default()
+        }
+    }
 
-	pub fn should_colorize(&self) -> bool {
-		if self.has_manual_override.load(Ordering::Relaxed) {
-			return self.manual_override.load(Ordering::Relaxed);
-		}
+    pub fn should_colorize(&self) -> bool {
+        if self.has_manual_override.load(Ordering::Relaxed) {
+            return self.manual_override.load(Ordering::Relaxed);
+        }
 
-		if let Some(forced_value) = self.clicolor_force {
-			return forced_value;
-		}
+        if let Some(forced_value) = self.clicolor_force {
+            return forced_value;
+        }
 
-		if let Some(value) = self.clicolor {
-			return value;
-		}
+        if let Some(value) = self.clicolor {
+            return value;
+        }
 
-		true
-	}
+        true
+    }
 
-	pub fn set_override(&self, override_colorize: bool) {
-		self.has_manual_override.store(true, Ordering::Relaxed);
-		self.manual_override
-			.store(override_colorize, Ordering::Relaxed);
-	}
+    pub fn set_override(&self, override_colorize: bool) {
+        self.has_manual_override.store(true, Ordering::Relaxed);
+        self.manual_override
+            .store(override_colorize, Ordering::Relaxed);
+    }
 
-	pub fn unset_override(&self) {
-		self.has_manual_override.store(false, Ordering::Relaxed);
-	}
+    pub fn unset_override(&self) {
+        self.has_manual_override.store(false, Ordering::Relaxed);
+    }
 
-	/* private */
+    /* private */
 
-	fn normalize_env(env_res: Result<String, env::VarError>) -> Option<bool> {
-		match env_res {
-			Ok(string) => Some(string != "0"),
-			Err(_) => None,
-		}
-	}
+    fn normalize_env(env_res: Result<String, env::VarError>) -> Option<bool> {
+        match env_res {
+            Ok(string) => Some(string != "0"),
+            Err(_) => None,
+        }
+    }
 
-	fn resolve_clicolor_force(
-		no_color: Result<String, env::VarError>,
-		clicolor_force: Result<String, env::VarError>,
-	) -> Option<bool> {
-		match (
-			ShouldColorize::normalize_env(no_color),
-			ShouldColorize::normalize_env(clicolor_force),
-		) {
-			(_, Some(b)) => Some(b),
-			(Some(_), None) => Some(false),
-			(None, None) => None,
-		}
-	}
+    fn resolve_clicolor_force(
+        no_color: Result<String, env::VarError>,
+        clicolor_force: Result<String, env::VarError>,
+    ) -> Option<bool> {
+        match (
+            ShouldColorize::normalize_env(no_color),
+            ShouldColorize::normalize_env(clicolor_force),
+        ) {
+            (_, Some(b)) => Some(b),
+            (Some(_), None) => Some(false),
+            (None, None) => None,
+        }
+    }
 }
 
 #[cfg(test)]
 mod specs {
-	use super::*;
-	use rspec;
-	use rspec::context::*;
-	use std::env;
+    use super::*;
+    use rspec;
+    use rspec::context::*;
+    use std::env;
 
-	#[test]
-	fn clicolor_behavior() {
-		use std::io;
+    #[test]
+    fn clicolor_behavior() {
+        use std::io;
 
-		let stdout = &mut io::stdout();
-		let mut formatter = rspec::formatter::Simple::new(stdout);
-		let mut runner = describe("ShouldColorize", |ctx| {
-			ctx.describe("::normalize_env", |ctx| {
-				ctx.it("should return None if error", || {
-					assert_eq!(
-						None,
-						ShouldColorize::normalize_env(Err(env::VarError::NotPresent))
-					);
-					assert_eq!(
-						None,
-						ShouldColorize::normalize_env(Err(env::VarError::NotUnicode("".into())))
-					)
-				});
+        let stdout = &mut io::stdout();
+        let mut formatter = rspec::formatter::Simple::new(stdout);
+        let mut runner = describe("ShouldColorize", |ctx| {
+            ctx.describe("::normalize_env", |ctx| {
+                ctx.it("should return None if error", || {
+                    assert_eq!(
+                        None,
+                        ShouldColorize::normalize_env(Err(env::VarError::NotPresent))
+                    );
+                    assert_eq!(
+                        None,
+                        ShouldColorize::normalize_env(Err(env::VarError::NotUnicode("".into())))
+                    )
+                });
 
-				ctx.it("should return Some(true) if != 0", || {
-					Some(true) == ShouldColorize::normalize_env(Ok(String::from("1")))
-				});
+                ctx.it("should return Some(true) if != 0", || {
+                    Some(true) == ShouldColorize::normalize_env(Ok(String::from("1")))
+                });
 
-				ctx.it("should return Some(false) if == 0", || {
-					Some(false) == ShouldColorize::normalize_env(Ok(String::from("0")))
-				});
-			});
+                ctx.it("should return Some(false) if == 0", || {
+                    Some(false) == ShouldColorize::normalize_env(Ok(String::from("0")))
+                });
+            });
 
-			ctx.describe("::resolve_clicolor_force", |ctx| {
+            ctx.describe("::resolve_clicolor_force", |ctx| {
                 ctx.it(
                     "should return None if neither NO_COLOR nor CLICOLOR_FORCE are set",
                     || {
@@ -246,67 +246,67 @@ mod specs {
                 );
             });
 
-			ctx.describe("constructors", |ctx| {
-				ctx.it("should have a default constructor", || {
-					ShouldColorize::default();
-				});
+            ctx.describe("constructors", |ctx| {
+                ctx.it("should have a default constructor", || {
+                    ShouldColorize::default();
+                });
 
-				ctx.it("should have an environment constructor", || {
-					ShouldColorize::from_env();
-				});
-			});
+                ctx.it("should have an environment constructor", || {
+                    ShouldColorize::from_env();
+                });
+            });
 
-			ctx.describe("when only changing clicolors", |ctx| {
-				ctx.it("clicolor == false means no colors", || {
-					let colorize_control = ShouldColorize {
-						clicolor: Some(false),
-						..ShouldColorize::default()
-					};
-					false == colorize_control.should_colorize()
-				});
+            ctx.describe("when only changing clicolors", |ctx| {
+                ctx.it("clicolor == false means no colors", || {
+                    let colorize_control = ShouldColorize {
+                        clicolor: Some(false),
+                        ..ShouldColorize::default()
+                    };
+                    false == colorize_control.should_colorize()
+                });
 
-				ctx.it("clicolor == true means colors !", || {
-					let colorize_control = ShouldColorize {
-						clicolor: Some(true),
-						..ShouldColorize::default()
-					};
-					true == colorize_control.should_colorize()
-				});
+                ctx.it("clicolor == true means colors !", || {
+                    let colorize_control = ShouldColorize {
+                        clicolor: Some(true),
+                        ..ShouldColorize::default()
+                    };
+                    true == colorize_control.should_colorize()
+                });
 
-				ctx.it("unset clicolors implies true", || {
-					true == ShouldColorize::default().should_colorize()
-				});
-			});
+                ctx.it("unset clicolors implies true", || {
+                    true == ShouldColorize::default().should_colorize()
+                });
+            });
 
-			ctx.describe("when using clicolor_force", |ctx| {
-				ctx.it(
-					"clicolor_force should force to true no matter clicolor",
-					|| {
-						let colorize_control = ShouldColorize {
-							clicolor: Some(false),
-							clicolor_force: Some(true),
-							..ShouldColorize::default()
-						};
+            ctx.describe("when using clicolor_force", |ctx| {
+                ctx.it(
+                    "clicolor_force should force to true no matter clicolor",
+                    || {
+                        let colorize_control = ShouldColorize {
+                            clicolor: Some(false),
+                            clicolor_force: Some(true),
+                            ..ShouldColorize::default()
+                        };
 
-						true == colorize_control.should_colorize()
-					},
-				);
+                        true == colorize_control.should_colorize()
+                    },
+                );
 
-				ctx.it(
-					"clicolor_force should force to false no matter clicolor",
-					|| {
-						let colorize_control = ShouldColorize {
-							clicolor: Some(true),
-							clicolor_force: Some(false),
-							..ShouldColorize::default()
-						};
+                ctx.it(
+                    "clicolor_force should force to false no matter clicolor",
+                    || {
+                        let colorize_control = ShouldColorize {
+                            clicolor: Some(true),
+                            clicolor_force: Some(false),
+                            ..ShouldColorize::default()
+                        };
 
-						false == colorize_control.should_colorize()
-					},
-				);
-			});
+                        false == colorize_control.should_colorize()
+                    },
+                );
+            });
 
-			ctx.describe("using a manual override", |ctx| {
+            ctx.describe("using a manual override", |ctx| {
                 ctx.it("shoud colorize if manual_override is true, but clicolor is false and clicolor_force also false", || {
                     let colorize_control = ShouldColorize {
                         clicolor: Some(false),
@@ -332,53 +332,53 @@ mod specs {
                 })
             });
 
-			ctx.describe("::set_override", |ctx| {
-				ctx.it("should exists", || {
-					let colorize_control = ShouldColorize::default();
-					colorize_control.set_override(true);
-				});
+            ctx.describe("::set_override", |ctx| {
+                ctx.it("should exists", || {
+                    let colorize_control = ShouldColorize::default();
+                    colorize_control.set_override(true);
+                });
 
-				ctx.it("set the manual_override property", || {
-					let colorize_control = ShouldColorize::default();
-					colorize_control.set_override(true);
-					{
-						assert_eq!(
-							true,
-							colorize_control.has_manual_override.load(Ordering::Relaxed)
-						);
-						let val = colorize_control.manual_override.load(Ordering::Relaxed);
-						assert_eq!(true, val);
-					}
-					colorize_control.set_override(false);
-					{
-						assert_eq!(
-							true,
-							colorize_control.has_manual_override.load(Ordering::Relaxed)
-						);
-						let val = colorize_control.manual_override.load(Ordering::Relaxed);
-						assert_eq!(false, val);
-					}
-				});
-			});
+                ctx.it("set the manual_override property", || {
+                    let colorize_control = ShouldColorize::default();
+                    colorize_control.set_override(true);
+                    {
+                        assert_eq!(
+                            true,
+                            colorize_control.has_manual_override.load(Ordering::Relaxed)
+                        );
+                        let val = colorize_control.manual_override.load(Ordering::Relaxed);
+                        assert_eq!(true, val);
+                    }
+                    colorize_control.set_override(false);
+                    {
+                        assert_eq!(
+                            true,
+                            colorize_control.has_manual_override.load(Ordering::Relaxed)
+                        );
+                        let val = colorize_control.manual_override.load(Ordering::Relaxed);
+                        assert_eq!(false, val);
+                    }
+                });
+            });
 
-			ctx.describe("::unset_override", |ctx| {
-				ctx.it("should exists", || {
-					let colorize_control = ShouldColorize::default();
-					colorize_control.unset_override();
-				});
+            ctx.describe("::unset_override", |ctx| {
+                ctx.it("should exists", || {
+                    let colorize_control = ShouldColorize::default();
+                    colorize_control.unset_override();
+                });
 
-				ctx.it("unset the manual_override property", || {
-					let colorize_control = ShouldColorize::default();
-					colorize_control.set_override(true);
-					colorize_control.unset_override();
-					assert_eq!(
-						false,
-						colorize_control.has_manual_override.load(Ordering::Relaxed)
-					);
-				});
-			});
-		});
-		runner.add_event_handler(&mut formatter);
-		runner.run().unwrap();
-	}
+                ctx.it("unset the manual_override property", || {
+                    let colorize_control = ShouldColorize::default();
+                    colorize_control.set_override(true);
+                    colorize_control.unset_override();
+                    assert_eq!(
+                        false,
+                        colorize_control.has_manual_override.load(Ordering::Relaxed)
+                    );
+                });
+            });
+        });
+        runner.add_event_handler(&mut formatter);
+        runner.run().unwrap();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,10 @@ use std::string::String;
 /// A string that may have color and/or style applied to it.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ColoredString {
-	input: String,
-	fgcolor: Option<Color>,
-	bgcolor: Option<Color>,
-	style: style::Style,
+    input: String,
+    fgcolor: Option<Color>,
+    bgcolor: Option<Color>,
+    style: style::Style,
 }
 
 /// The trait that enables something to be given color.
@@ -57,174 +57,173 @@ pub struct ColoredString {
 /// You can use `colored` effectively simply by importing this trait
 /// and then using its methods on `String` and `&str`.
 pub trait Colorize {
-	// Font Colors
-	fn black(self) -> ColoredString;
-	fn red(self) -> ColoredString;
-	fn green(self) -> ColoredString;
-	fn yellow(self) -> ColoredString;
-	fn blue(self) -> ColoredString;
-	fn magenta(self) -> ColoredString;
-	fn purple(self) -> ColoredString;
-	fn cyan(self) -> ColoredString;
-	fn white(self) -> ColoredString;
-	fn bright_black(self) -> ColoredString;
-	fn bright_red(self) -> ColoredString;
-	fn bright_green(self) -> ColoredString;
-	fn bright_yellow(self) -> ColoredString;
-	fn bright_blue(self) -> ColoredString;
-	fn bright_magenta(self) -> ColoredString;
-	fn bright_purple(self) -> ColoredString;
-	fn bright_cyan(self) -> ColoredString;
-	fn bright_white(self) -> ColoredString;
-	fn color<S: Into<Color>>(self, color: S) -> ColoredString;
-	// Background Colors
-	fn on_black(self) -> ColoredString;
-	fn on_red(self) -> ColoredString;
-	fn on_green(self) -> ColoredString;
-	fn on_yellow(self) -> ColoredString;
-	fn on_blue(self) -> ColoredString;
-	fn on_magenta(self) -> ColoredString;
-	fn on_purple(self) -> ColoredString;
-	fn on_cyan(self) -> ColoredString;
-	fn on_white(self) -> ColoredString;
-	fn on_bright_black(self) -> ColoredString;
-	fn on_bright_red(self) -> ColoredString;
-	fn on_bright_green(self) -> ColoredString;
-	fn on_bright_yellow(self) -> ColoredString;
-	fn on_bright_blue(self) -> ColoredString;
-	fn on_bright_magenta(self) -> ColoredString;
-	fn on_bright_purple(self) -> ColoredString;
-	fn on_bright_cyan(self) -> ColoredString;
-	fn on_bright_white(self) -> ColoredString;
-	fn on_color<S: Into<Color>>(self, color: S) -> ColoredString;
-	// Styles
-	fn clear(self) -> ColoredString;
-	fn normal(self) -> ColoredString;
-	fn bold(self) -> ColoredString;
-	fn dimmed(self) -> ColoredString;
-	fn italic(self) -> ColoredString;
-	fn underline(self) -> ColoredString;
-	fn blink(self) -> ColoredString;
-	/// Historical name of `Colorize::reversed`. May be removed in a future version. Please use
-	/// `Colorize::reversed` instead
-	fn reverse(self) -> ColoredString;
-	/// This should be preferred to `Colorize::reverse`.
-	fn reversed(self) -> ColoredString;
-	fn hidden(self) -> ColoredString;
-	fn strikethrough(self) -> ColoredString;
+    // Font Colors
+    fn black(self) -> ColoredString;
+    fn red(self) -> ColoredString;
+    fn green(self) -> ColoredString;
+    fn yellow(self) -> ColoredString;
+    fn blue(self) -> ColoredString;
+    fn magenta(self) -> ColoredString;
+    fn purple(self) -> ColoredString;
+    fn cyan(self) -> ColoredString;
+    fn white(self) -> ColoredString;
+    fn bright_black(self) -> ColoredString;
+    fn bright_red(self) -> ColoredString;
+    fn bright_green(self) -> ColoredString;
+    fn bright_yellow(self) -> ColoredString;
+    fn bright_blue(self) -> ColoredString;
+    fn bright_magenta(self) -> ColoredString;
+    fn bright_purple(self) -> ColoredString;
+    fn bright_cyan(self) -> ColoredString;
+    fn bright_white(self) -> ColoredString;
+    fn color<S: Into<Color>>(self, color: S) -> ColoredString;
+    // Background Colors
+    fn on_black(self) -> ColoredString;
+    fn on_red(self) -> ColoredString;
+    fn on_green(self) -> ColoredString;
+    fn on_yellow(self) -> ColoredString;
+    fn on_blue(self) -> ColoredString;
+    fn on_magenta(self) -> ColoredString;
+    fn on_purple(self) -> ColoredString;
+    fn on_cyan(self) -> ColoredString;
+    fn on_white(self) -> ColoredString;
+    fn on_bright_black(self) -> ColoredString;
+    fn on_bright_red(self) -> ColoredString;
+    fn on_bright_green(self) -> ColoredString;
+    fn on_bright_yellow(self) -> ColoredString;
+    fn on_bright_blue(self) -> ColoredString;
+    fn on_bright_magenta(self) -> ColoredString;
+    fn on_bright_purple(self) -> ColoredString;
+    fn on_bright_cyan(self) -> ColoredString;
+    fn on_bright_white(self) -> ColoredString;
+    fn on_color<S: Into<Color>>(self, color: S) -> ColoredString;
+    // Styles
+    fn clear(self) -> ColoredString;
+    fn normal(self) -> ColoredString;
+    fn bold(self) -> ColoredString;
+    fn dimmed(self) -> ColoredString;
+    fn italic(self) -> ColoredString;
+    fn underline(self) -> ColoredString;
+    fn blink(self) -> ColoredString;
+    /// Historical name of `Colorize::reversed`. May be removed in a future version. Please use
+    /// `Colorize::reversed` instead
+    fn reverse(self) -> ColoredString;
+    /// This should be preferred to `Colorize::reverse`.
+    fn reversed(self) -> ColoredString;
+    fn hidden(self) -> ColoredString;
+    fn strikethrough(self) -> ColoredString;
 }
 
 impl ColoredString {
-	pub fn is_plain(&self) -> bool {
-		(self.bgcolor.is_none() && self.fgcolor.is_none() && self.style == style::CLEAR)
-	}
+    pub fn is_plain(&self) -> bool {
+        (self.bgcolor.is_none() && self.fgcolor.is_none() && self.style == style::CLEAR)
+    }
 
-	#[cfg(not(feature = "no-color"))]
-	fn has_colors(&self) -> bool {
-		use control;
+    #[cfg(not(feature = "no-color"))]
+    fn has_colors(&self) -> bool {
+        use control;
 
-		control::SHOULD_COLORIZE.should_colorize()
-	}
+        control::SHOULD_COLORIZE.should_colorize()
+    }
 
-	#[cfg(feature = "no-color")]
-	fn has_colors(&self) -> bool {
-		false
-	}
+    #[cfg(feature = "no-color")]
+    fn has_colors(&self) -> bool {
+        false
+    }
 
-	fn compute_style(&self) -> String {
-		if !self.has_colors() || self.is_plain() {
-			return String::new();
-		}
+    fn compute_style(&self) -> String {
+        if !self.has_colors() || self.is_plain() {
+            return String::new();
+        }
 
-		let mut res = String::from("\x1B[");
-		let mut has_wrote = if self.style != style::CLEAR {
-			res.push_str(&self.style.to_str());
-			true
-		} else {
-			false
-		};
+        let mut res = String::from("\x1B[");
+        let mut has_wrote = if self.style != style::CLEAR {
+            res.push_str(&self.style.to_str());
+            true
+        } else {
+            false
+        };
 
-		if let Some(ref bgcolor) = self.bgcolor {
-			if has_wrote {
-				res.push(';');
-			}
+        if let Some(ref bgcolor) = self.bgcolor {
+            if has_wrote {
+                res.push(';');
+            }
 
-			res.push_str(bgcolor.to_bg_str());
-			has_wrote = true;
-		}
+            res.push_str(bgcolor.to_bg_str());
+            has_wrote = true;
+        }
 
-		if let Some(ref fgcolor) = self.fgcolor {
-			if has_wrote {
-				res.push(';');
-			}
+        if let Some(ref fgcolor) = self.fgcolor {
+            if has_wrote {
+                res.push(';');
+            }
 
-			res.push_str(fgcolor.to_fg_str());
-		}
+            res.push_str(fgcolor.to_fg_str());
+        }
 
-		res.push('m');
-		res
-	}
+        res.push('m');
+        res
+    }
 
-	fn escape_inner_reset_sequences(&self) -> String {
-		if !self.has_colors() || self.is_plain() {
-			return self.input.clone();
-		}
+    fn escape_inner_reset_sequences(&self) -> String {
+        if !self.has_colors() || self.is_plain() {
+            return self.input.clone();
+        }
 
-		// TODO: BoyScoutRule
-		let reset = "\x1B[0m";
-		let style = self.compute_style();
-		let matches: Vec<usize> = self
-			.input
-			.match_indices(reset)
-			.map(|(idx, _)| idx)
-			.collect();
+        // TODO: BoyScoutRule
+        let reset = "\x1B[0m";
+        let style = self.compute_style();
+        let matches: Vec<usize> = self.input
+            .match_indices(reset)
+            .map(|(idx, _)| idx)
+            .collect();
 
-		let mut idx_in_matches = 0;
-		let mut input = self.input.clone();
-		input.reserve(matches.len() * style.len());
+        let mut idx_in_matches = 0;
+        let mut input = self.input.clone();
+        input.reserve(matches.len() * style.len());
 
-		for offset in matches {
-			// shift the offset to the end of the reset sequence and take in account
-			// the number of matches we have escaped (which shift the index to insert)
-			let mut offset = offset + reset.len() + idx_in_matches * style.len();
+        for offset in matches {
+            // shift the offset to the end of the reset sequence and take in account
+            // the number of matches we have escaped (which shift the index to insert)
+            let mut offset = offset + reset.len() + idx_in_matches * style.len();
 
-			for cchar in style.chars() {
-				input.insert(offset, cchar);
-				offset += 1;
-			}
+            for cchar in style.chars() {
+                input.insert(offset, cchar);
+                offset += 1;
+            }
 
-			idx_in_matches += 1;
-		}
+            idx_in_matches += 1;
+        }
 
-		input
-	}
+        input
+    }
 }
 
 impl Default for ColoredString {
-	fn default() -> Self {
-		ColoredString {
-			input: String::default(),
-			fgcolor: None,
-			bgcolor: None,
-			style: style::CLEAR,
-		}
-	}
+    fn default() -> Self {
+        ColoredString {
+            input: String::default(),
+            fgcolor: None,
+            bgcolor: None,
+            style: style::CLEAR,
+        }
+    }
 }
 
 impl Deref for ColoredString {
-	type Target = str;
-	fn deref(&self) -> &str {
-		&self.input
-	}
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.input
+    }
 }
 
 impl<'a> From<&'a str> for ColoredString {
-	fn from(s: &'a str) -> Self {
-		ColoredString {
-			input: String::from(s),
-			..ColoredString::default()
-		}
-	}
+    fn from(s: &'a str) -> Self {
+        ColoredString {
+            input: String::from(s),
+            ..ColoredString::default()
+        }
+    }
 }
 
 macro_rules! def_color {
@@ -249,91 +248,91 @@ macro_rules! def_style {
 }
 
 impl Colorize for ColoredString {
-	def_color!(fgcolor: black => Color::Black);
-	fn red(self) -> ColoredString {
-		self.color(Color::Red)
-	}
-	def_color!(fgcolor: green => Color::Green);
-	def_color!(fgcolor: yellow => Color::Yellow);
-	def_color!(fgcolor: blue => Color::Blue);
-	def_color!(fgcolor: magenta => Color::Magenta);
-	def_color!(fgcolor: purple => Color::Magenta);
-	def_color!(fgcolor: cyan => Color::Cyan);
-	def_color!(fgcolor: white => Color::White);
-	def_color!(fgcolor: bright_black => Color::BrightBlack);
-	fn bright_red(self) -> ColoredString {
-		self.color(Color::BrightRed)
-	}
-	def_color!(fgcolor: bright_green => Color::BrightGreen);
-	def_color!(fgcolor: bright_yellow => Color::BrightYellow);
-	def_color!(fgcolor: bright_blue => Color::BrightBlue);
-	def_color!(fgcolor: bright_magenta => Color::BrightMagenta);
-	def_color!(fgcolor: bright_purple => Color::BrightMagenta);
-	def_color!(fgcolor: bright_cyan => Color::BrightCyan);
-	def_color!(fgcolor: bright_white => Color::BrightWhite);
+    def_color!(fgcolor: black => Color::Black);
+    fn red(self) -> ColoredString {
+        self.color(Color::Red)
+    }
+    def_color!(fgcolor: green => Color::Green);
+    def_color!(fgcolor: yellow => Color::Yellow);
+    def_color!(fgcolor: blue => Color::Blue);
+    def_color!(fgcolor: magenta => Color::Magenta);
+    def_color!(fgcolor: purple => Color::Magenta);
+    def_color!(fgcolor: cyan => Color::Cyan);
+    def_color!(fgcolor: white => Color::White);
+    def_color!(fgcolor: bright_black => Color::BrightBlack);
+    fn bright_red(self) -> ColoredString {
+        self.color(Color::BrightRed)
+    }
+    def_color!(fgcolor: bright_green => Color::BrightGreen);
+    def_color!(fgcolor: bright_yellow => Color::BrightYellow);
+    def_color!(fgcolor: bright_blue => Color::BrightBlue);
+    def_color!(fgcolor: bright_magenta => Color::BrightMagenta);
+    def_color!(fgcolor: bright_purple => Color::BrightMagenta);
+    def_color!(fgcolor: bright_cyan => Color::BrightCyan);
+    def_color!(fgcolor: bright_white => Color::BrightWhite);
 
-	fn color<S: Into<Color>>(self, color: S) -> ColoredString {
-		ColoredString {
-			fgcolor: Some(color.into()),
-			..self
-		}
-	}
+    fn color<S: Into<Color>>(self, color: S) -> ColoredString {
+        ColoredString {
+            fgcolor: Some(color.into()),
+            ..self
+        }
+    }
 
-	def_color!(bgcolor: on_black => Color::Black);
-	fn on_red(self) -> ColoredString {
-		ColoredString {
-			bgcolor: Some(Color::Red),
-			..self
-		}
-	}
-	def_color!(bgcolor: on_green => Color::Green);
-	def_color!(bgcolor: on_yellow => Color::Yellow);
-	def_color!(bgcolor: on_blue => Color::Blue);
-	def_color!(bgcolor: on_magenta => Color::Magenta);
-	def_color!(bgcolor: on_purple => Color::Magenta);
-	def_color!(bgcolor: on_cyan => Color::Cyan);
-	def_color!(bgcolor: on_white => Color::White);
+    def_color!(bgcolor: on_black => Color::Black);
+    fn on_red(self) -> ColoredString {
+        ColoredString {
+            bgcolor: Some(Color::Red),
+            ..self
+        }
+    }
+    def_color!(bgcolor: on_green => Color::Green);
+    def_color!(bgcolor: on_yellow => Color::Yellow);
+    def_color!(bgcolor: on_blue => Color::Blue);
+    def_color!(bgcolor: on_magenta => Color::Magenta);
+    def_color!(bgcolor: on_purple => Color::Magenta);
+    def_color!(bgcolor: on_cyan => Color::Cyan);
+    def_color!(bgcolor: on_white => Color::White);
 
-	def_color!(bgcolor: on_bright_black => Color::BrightBlack);
-	fn on_bright_red(self) -> ColoredString {
-		ColoredString {
-			bgcolor: Some(Color::BrightRed),
-			..self
-		}
-	}
-	def_color!(bgcolor: on_bright_green => Color::BrightGreen);
-	def_color!(bgcolor: on_bright_yellow => Color::BrightYellow);
-	def_color!(bgcolor: on_bright_blue => Color::BrightBlue);
-	def_color!(bgcolor: on_bright_magenta => Color::BrightMagenta);
-	def_color!(bgcolor: on_bright_purple => Color::BrightMagenta);
-	def_color!(bgcolor: on_bright_cyan => Color::BrightCyan);
-	def_color!(bgcolor: on_bright_white => Color::BrightWhite);
+    def_color!(bgcolor: on_bright_black => Color::BrightBlack);
+    fn on_bright_red(self) -> ColoredString {
+        ColoredString {
+            bgcolor: Some(Color::BrightRed),
+            ..self
+        }
+    }
+    def_color!(bgcolor: on_bright_green => Color::BrightGreen);
+    def_color!(bgcolor: on_bright_yellow => Color::BrightYellow);
+    def_color!(bgcolor: on_bright_blue => Color::BrightBlue);
+    def_color!(bgcolor: on_bright_magenta => Color::BrightMagenta);
+    def_color!(bgcolor: on_bright_purple => Color::BrightMagenta);
+    def_color!(bgcolor: on_bright_cyan => Color::BrightCyan);
+    def_color!(bgcolor: on_bright_white => Color::BrightWhite);
 
-	fn on_color<S: Into<Color>>(self, color: S) -> ColoredString {
-		ColoredString {
-			bgcolor: Some(color.into()),
-			..self
-		}
-	}
+    fn on_color<S: Into<Color>>(self, color: S) -> ColoredString {
+        ColoredString {
+            bgcolor: Some(color.into()),
+            ..self
+        }
+    }
 
-	fn clear(self) -> ColoredString {
-		ColoredString {
-			input: self.input,
-			..ColoredString::default()
-		}
-	}
-	fn normal(self) -> ColoredString {
-		self.clear()
-	}
-	def_style!(bold, style::Styles::Bold);
-	def_style!(dimmed, style::Styles::Dimmed);
-	def_style!(italic, style::Styles::Italic);
-	def_style!(underline, style::Styles::Underline);
-	def_style!(blink, style::Styles::Blink);
-	def_style!(reverse, style::Styles::Reversed);
-	def_style!(reversed, style::Styles::Reversed);
-	def_style!(hidden, style::Styles::Hidden);
-	def_style!(strikethrough, style::Styles::Strikethrough);
+    fn clear(self) -> ColoredString {
+        ColoredString {
+            input: self.input,
+            ..ColoredString::default()
+        }
+    }
+    fn normal(self) -> ColoredString {
+        self.clear()
+    }
+    def_style!(bold, style::Styles::Bold);
+    def_style!(dimmed, style::Styles::Dimmed);
+    def_style!(italic, style::Styles::Italic);
+    def_style!(underline, style::Styles::Underline);
+    def_style!(blink, style::Styles::Blink);
+    def_style!(reverse, style::Styles::Reversed);
+    def_style!(reversed, style::Styles::Reversed);
+    def_style!(hidden, style::Styles::Hidden);
+    def_style!(strikethrough, style::Styles::Strikethrough);
 }
 
 macro_rules! def_str_color {
@@ -361,328 +360,328 @@ macro_rules! def_str_style {
 }
 
 impl<'a> Colorize for &'a str {
-	def_str_color!(fgcolor: black => Color::Black);
-	fn red(self) -> ColoredString {
-		ColoredString {
-			input: String::from(self),
-			fgcolor: Some(Color::Red),
-			..ColoredString::default()
-		}
-	}
-	def_str_color!(fgcolor: green => Color::Green);
-	def_str_color!(fgcolor: yellow => Color::Yellow);
-	def_str_color!(fgcolor: blue => Color::Blue);
-	def_str_color!(fgcolor: magenta => Color::Magenta);
-	def_str_color!(fgcolor: purple => Color::Magenta);
-	def_str_color!(fgcolor: cyan => Color::Cyan);
-	def_str_color!(fgcolor: white => Color::White);
+    def_str_color!(fgcolor: black => Color::Black);
+    fn red(self) -> ColoredString {
+        ColoredString {
+            input: String::from(self),
+            fgcolor: Some(Color::Red),
+            ..ColoredString::default()
+        }
+    }
+    def_str_color!(fgcolor: green => Color::Green);
+    def_str_color!(fgcolor: yellow => Color::Yellow);
+    def_str_color!(fgcolor: blue => Color::Blue);
+    def_str_color!(fgcolor: magenta => Color::Magenta);
+    def_str_color!(fgcolor: purple => Color::Magenta);
+    def_str_color!(fgcolor: cyan => Color::Cyan);
+    def_str_color!(fgcolor: white => Color::White);
 
-	def_str_color!(fgcolor: bright_black => Color::BrightBlack);
-	fn bright_red(self) -> ColoredString {
-		ColoredString {
-			input: String::from(self),
-			fgcolor: Some(Color::BrightRed),
-			..ColoredString::default()
-		}
-	}
-	def_str_color!(fgcolor: bright_green => Color::BrightGreen);
-	def_str_color!(fgcolor: bright_yellow => Color::BrightYellow);
-	def_str_color!(fgcolor: bright_blue => Color::BrightBlue);
-	def_str_color!(fgcolor: bright_magenta => Color::BrightMagenta);
-	def_str_color!(fgcolor: bright_purple => Color::BrightMagenta);
-	def_str_color!(fgcolor: bright_cyan => Color::BrightCyan);
-	def_str_color!(fgcolor: bright_white => Color::BrightWhite);
+    def_str_color!(fgcolor: bright_black => Color::BrightBlack);
+    fn bright_red(self) -> ColoredString {
+        ColoredString {
+            input: String::from(self),
+            fgcolor: Some(Color::BrightRed),
+            ..ColoredString::default()
+        }
+    }
+    def_str_color!(fgcolor: bright_green => Color::BrightGreen);
+    def_str_color!(fgcolor: bright_yellow => Color::BrightYellow);
+    def_str_color!(fgcolor: bright_blue => Color::BrightBlue);
+    def_str_color!(fgcolor: bright_magenta => Color::BrightMagenta);
+    def_str_color!(fgcolor: bright_purple => Color::BrightMagenta);
+    def_str_color!(fgcolor: bright_cyan => Color::BrightCyan);
+    def_str_color!(fgcolor: bright_white => Color::BrightWhite);
 
-	fn color<S: Into<Color>>(self, color: S) -> ColoredString {
-		ColoredString {
-			fgcolor: Some(color.into()),
-			input: String::from(self),
-			..ColoredString::default()
-		}
-	}
+    fn color<S: Into<Color>>(self, color: S) -> ColoredString {
+        ColoredString {
+            fgcolor: Some(color.into()),
+            input: String::from(self),
+            ..ColoredString::default()
+        }
+    }
 
-	def_str_color!(bgcolor: on_black => Color::Black);
-	fn on_red(self) -> ColoredString {
-		ColoredString {
-			input: String::from(self),
-			bgcolor: Some(Color::Red),
-			..ColoredString::default()
-		}
-	}
-	def_str_color!(bgcolor: on_green => Color::Green);
-	def_str_color!(bgcolor: on_yellow => Color::Yellow);
-	def_str_color!(bgcolor: on_blue => Color::Blue);
-	def_str_color!(bgcolor: on_magenta => Color::Magenta);
-	def_str_color!(bgcolor: on_purple => Color::Magenta);
-	def_str_color!(bgcolor: on_cyan => Color::Cyan);
-	def_str_color!(bgcolor: on_white => Color::White);
+    def_str_color!(bgcolor: on_black => Color::Black);
+    fn on_red(self) -> ColoredString {
+        ColoredString {
+            input: String::from(self),
+            bgcolor: Some(Color::Red),
+            ..ColoredString::default()
+        }
+    }
+    def_str_color!(bgcolor: on_green => Color::Green);
+    def_str_color!(bgcolor: on_yellow => Color::Yellow);
+    def_str_color!(bgcolor: on_blue => Color::Blue);
+    def_str_color!(bgcolor: on_magenta => Color::Magenta);
+    def_str_color!(bgcolor: on_purple => Color::Magenta);
+    def_str_color!(bgcolor: on_cyan => Color::Cyan);
+    def_str_color!(bgcolor: on_white => Color::White);
 
-	def_str_color!(bgcolor: on_bright_black => Color::BrightBlack);
-	fn on_bright_red(self) -> ColoredString {
-		ColoredString {
-			input: String::from(self),
-			bgcolor: Some(Color::BrightRed),
-			..ColoredString::default()
-		}
-	}
-	def_str_color!(bgcolor: on_bright_green => Color::BrightGreen);
-	def_str_color!(bgcolor: on_bright_yellow => Color::BrightYellow);
-	def_str_color!(bgcolor: on_bright_blue => Color::BrightBlue);
-	def_str_color!(bgcolor: on_bright_magenta => Color::BrightMagenta);
-	def_str_color!(bgcolor: on_bright_purple => Color::BrightMagenta);
-	def_str_color!(bgcolor: on_bright_cyan => Color::BrightCyan);
-	def_str_color!(bgcolor: on_bright_white => Color::BrightWhite);
+    def_str_color!(bgcolor: on_bright_black => Color::BrightBlack);
+    fn on_bright_red(self) -> ColoredString {
+        ColoredString {
+            input: String::from(self),
+            bgcolor: Some(Color::BrightRed),
+            ..ColoredString::default()
+        }
+    }
+    def_str_color!(bgcolor: on_bright_green => Color::BrightGreen);
+    def_str_color!(bgcolor: on_bright_yellow => Color::BrightYellow);
+    def_str_color!(bgcolor: on_bright_blue => Color::BrightBlue);
+    def_str_color!(bgcolor: on_bright_magenta => Color::BrightMagenta);
+    def_str_color!(bgcolor: on_bright_purple => Color::BrightMagenta);
+    def_str_color!(bgcolor: on_bright_cyan => Color::BrightCyan);
+    def_str_color!(bgcolor: on_bright_white => Color::BrightWhite);
 
-	fn on_color<S: Into<Color>>(self, color: S) -> ColoredString {
-		ColoredString {
-			bgcolor: Some(color.into()),
-			input: String::from(self),
-			..ColoredString::default()
-		}
-	}
+    fn on_color<S: Into<Color>>(self, color: S) -> ColoredString {
+        ColoredString {
+            bgcolor: Some(color.into()),
+            input: String::from(self),
+            ..ColoredString::default()
+        }
+    }
 
-	fn clear(self) -> ColoredString {
-		ColoredString {
-			input: String::from(self),
-			style: style::CLEAR,
-			..ColoredString::default()
-		}
-	}
-	fn normal(self) -> ColoredString {
-		self.clear()
-	}
-	def_str_style!(bold, style::Styles::Bold);
-	def_str_style!(dimmed, style::Styles::Dimmed);
-	def_str_style!(italic, style::Styles::Italic);
-	def_str_style!(underline, style::Styles::Underline);
-	def_str_style!(blink, style::Styles::Blink);
-	def_str_style!(reverse, style::Styles::Reversed);
-	def_str_style!(reversed, style::Styles::Reversed);
-	def_str_style!(hidden, style::Styles::Hidden);
-	def_str_style!(strikethrough, style::Styles::Strikethrough);
+    fn clear(self) -> ColoredString {
+        ColoredString {
+            input: String::from(self),
+            style: style::CLEAR,
+            ..ColoredString::default()
+        }
+    }
+    fn normal(self) -> ColoredString {
+        self.clear()
+    }
+    def_str_style!(bold, style::Styles::Bold);
+    def_str_style!(dimmed, style::Styles::Dimmed);
+    def_str_style!(italic, style::Styles::Italic);
+    def_str_style!(underline, style::Styles::Underline);
+    def_str_style!(blink, style::Styles::Blink);
+    def_str_style!(reverse, style::Styles::Reversed);
+    def_str_style!(reversed, style::Styles::Reversed);
+    def_str_style!(hidden, style::Styles::Hidden);
+    def_str_style!(strikethrough, style::Styles::Strikethrough);
 }
 
 impl fmt::Display for ColoredString {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		if !self.has_colors() || self.is_plain() {
-			return (<String as fmt::Display>::fmt(&self.input, f));
-		}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if !self.has_colors() || self.is_plain() {
+            return (<String as fmt::Display>::fmt(&self.input, f));
+        }
 
-		// XXX: see tests. Useful when nesting colored strings
-		let escaped_input = self.escape_inner_reset_sequences();
+        // XXX: see tests. Useful when nesting colored strings
+        let escaped_input = self.escape_inner_reset_sequences();
 
-		try!(f.write_str(&self.compute_style()));
-		try!(<String as fmt::Display>::fmt(&escaped_input, f));
-		try!(f.write_str("\x1B[0m"));
-		Ok(())
-	}
+        try!(f.write_str(&self.compute_style()));
+        try!(<String as fmt::Display>::fmt(&escaped_input, f));
+        try!(f.write_str("\x1B[0m"));
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn formatting() {
-		// respect the formatting. Escape sequence add some padding so >= 40
-		assert!(format!("{:40}", "".blue()).len() >= 40);
-		// both should be truncated to 1 char before coloring
-		assert_eq!(
-			format!("{:1.1}", "toto".blue()).len(),
-			format!("{:1.1}", "1".blue()).len()
-		)
-	}
+    #[test]
+    fn formatting() {
+        // respect the formatting. Escape sequence add some padding so >= 40
+        assert!(format!("{:40}", "".blue()).len() >= 40);
+        // both should be truncated to 1 char before coloring
+        assert_eq!(
+            format!("{:1.1}", "toto".blue()).len(),
+            format!("{:1.1}", "1".blue()).len()
+        )
+    }
 
-	#[test]
-	fn it_works() {
-		let toto = "toto";
-		println!("{}", toto.red());
-		println!("{}", String::from(toto).red());
-		println!("{}", toto.blue());
+    #[test]
+    fn it_works() {
+        let toto = "toto";
+        println!("{}", toto.red());
+        println!("{}", String::from(toto).red());
+        println!("{}", toto.blue());
 
-		println!("blue style ****");
-		println!("{}", toto.bold());
-		println!("{}", "yeah ! Red bold !".red().bold());
-		println!("{}", "yeah ! Yellow bold !".bold().yellow());
-		println!("{}", toto.bold().blue());
-		println!("{}", toto.blue().bold());
-		println!("{}", toto.blue().bold().underline());
-		println!("{}", toto.blue().italic());
-		println!("******");
-		println!("test clearing");
-		println!("{}", "red cleared".red().clear());
-		println!("{}", "bold cyan cleared".bold().cyan().clear());
-		println!("******");
-		println!("Bg tests");
-		println!("{}", toto.green().on_blue());
-		println!("{}", toto.on_magenta().yellow());
-		println!("{}", toto.purple().on_yellow());
-		println!("{}", toto.magenta().on_white());
-		println!("{}", toto.cyan().on_green());
-		println!("{}", toto.black().on_white());
-		println!("******");
-		println!("{}", toto.green());
-		println!("{}", toto.yellow());
-		println!("{}", toto.purple());
-		println!("{}", toto.magenta());
-		println!("{}", toto.cyan());
-		println!("{}", toto.white());
-		println!("{}", toto.white().red().blue().green());
-		// uncomment to see term output
-		// assert!(false)
-	}
+        println!("blue style ****");
+        println!("{}", toto.bold());
+        println!("{}", "yeah ! Red bold !".red().bold());
+        println!("{}", "yeah ! Yellow bold !".bold().yellow());
+        println!("{}", toto.bold().blue());
+        println!("{}", toto.blue().bold());
+        println!("{}", toto.blue().bold().underline());
+        println!("{}", toto.blue().italic());
+        println!("******");
+        println!("test clearing");
+        println!("{}", "red cleared".red().clear());
+        println!("{}", "bold cyan cleared".bold().cyan().clear());
+        println!("******");
+        println!("Bg tests");
+        println!("{}", toto.green().on_blue());
+        println!("{}", toto.on_magenta().yellow());
+        println!("{}", toto.purple().on_yellow());
+        println!("{}", toto.magenta().on_white());
+        println!("{}", toto.cyan().on_green());
+        println!("{}", toto.black().on_white());
+        println!("******");
+        println!("{}", toto.green());
+        println!("{}", toto.yellow());
+        println!("{}", toto.purple());
+        println!("{}", toto.magenta());
+        println!("{}", toto.cyan());
+        println!("{}", toto.white());
+        println!("{}", toto.white().red().blue().green());
+        // uncomment to see term output
+        // assert!(false)
+    }
 
-	#[test]
-	fn compute_style_empty_string() {
-		assert_eq!("", "".clear().compute_style());
-	}
+    #[test]
+    fn compute_style_empty_string() {
+        assert_eq!("", "".clear().compute_style());
+    }
 
-	#[test]
-	fn compute_style_simple_fg_blue() {
-		let blue = "\x1B[34m";
+    #[test]
+    fn compute_style_simple_fg_blue() {
+        let blue = "\x1B[34m";
 
-		assert_eq!(blue, "".blue().compute_style());
-	}
+        assert_eq!(blue, "".blue().compute_style());
+    }
 
-	#[test]
-	fn compute_style_simple_bg_blue() {
-		let on_blue = "\x1B[44m";
+    #[test]
+    fn compute_style_simple_bg_blue() {
+        let on_blue = "\x1B[44m";
 
-		assert_eq!(on_blue, "".on_blue().compute_style());
-	}
+        assert_eq!(on_blue, "".on_blue().compute_style());
+    }
 
-	#[test]
-	fn compute_style_blue_on_blue() {
-		let blue_on_blue = "\x1B[44;34m";
+    #[test]
+    fn compute_style_blue_on_blue() {
+        let blue_on_blue = "\x1B[44;34m";
 
-		assert_eq!(blue_on_blue, "".blue().on_blue().compute_style());
-	}
+        assert_eq!(blue_on_blue, "".blue().on_blue().compute_style());
+    }
 
-	#[test]
-	fn compute_style_simple_fg_bright_blue() {
-		let blue = "\x1B[94m";
+    #[test]
+    fn compute_style_simple_fg_bright_blue() {
+        let blue = "\x1B[94m";
 
-		assert_eq!(blue, "".bright_blue().compute_style());
-	}
+        assert_eq!(blue, "".bright_blue().compute_style());
+    }
 
-	#[test]
-	fn compute_style_simple_bg_bright_blue() {
-		let on_blue = "\x1B[104m";
+    #[test]
+    fn compute_style_simple_bg_bright_blue() {
+        let on_blue = "\x1B[104m";
 
-		assert_eq!(on_blue, "".on_bright_blue().compute_style());
-	}
+        assert_eq!(on_blue, "".on_bright_blue().compute_style());
+    }
 
-	#[test]
-	fn compute_style_bright_blue_on_bright_blue() {
-		let blue_on_blue = "\x1B[104;94m";
+    #[test]
+    fn compute_style_bright_blue_on_bright_blue() {
+        let blue_on_blue = "\x1B[104;94m";
 
-		assert_eq!(
-			blue_on_blue,
-			"".bright_blue().on_bright_blue().compute_style()
-		);
-	}
+        assert_eq!(
+            blue_on_blue,
+            "".bright_blue().on_bright_blue().compute_style()
+        );
+    }
 
-	#[test]
-	fn compute_style_simple_bold() {
-		let bold = "\x1B[1m";
+    #[test]
+    fn compute_style_simple_bold() {
+        let bold = "\x1B[1m";
 
-		assert_eq!(bold, "".bold().compute_style());
-	}
+        assert_eq!(bold, "".bold().compute_style());
+    }
 
-	#[test]
-	fn compute_style_blue_bold() {
-		let blue_bold = "\x1B[1;34m";
+    #[test]
+    fn compute_style_blue_bold() {
+        let blue_bold = "\x1B[1;34m";
 
-		assert_eq!(blue_bold, "".blue().bold().compute_style());
-	}
+        assert_eq!(blue_bold, "".blue().bold().compute_style());
+    }
 
-	#[test]
-	fn compute_style_blue_bold_on_blue() {
-		let blue_bold_on_blue = "\x1B[1;44;34m";
+    #[test]
+    fn compute_style_blue_bold_on_blue() {
+        let blue_bold_on_blue = "\x1B[1;44;34m";
 
-		assert_eq!(
-			blue_bold_on_blue,
-			"".blue().bold().on_blue().compute_style()
-		);
-	}
+        assert_eq!(
+            blue_bold_on_blue,
+            "".blue().bold().on_blue().compute_style()
+        );
+    }
 
-	#[test]
-	fn escape_reset_sequence_spec_should_do_nothing_on_empty_strings() {
-		let style = ColoredString::default();
-		let expected = String::new();
+    #[test]
+    fn escape_reset_sequence_spec_should_do_nothing_on_empty_strings() {
+        let style = ColoredString::default();
+        let expected = String::new();
 
-		let output = style.escape_inner_reset_sequences();
+        let output = style.escape_inner_reset_sequences();
 
-		assert_eq!(expected, output);
-	}
+        assert_eq!(expected, output);
+    }
 
-	#[test]
-	fn escape_reset_sequence_spec_should_do_nothing_on_string_with_no_reset() {
-		let style = ColoredString {
-			input: String::from("hello world !"),
-			..ColoredString::default()
-		};
+    #[test]
+    fn escape_reset_sequence_spec_should_do_nothing_on_string_with_no_reset() {
+        let style = ColoredString {
+            input: String::from("hello world !"),
+            ..ColoredString::default()
+        };
 
-		let expected = String::from("hello world !");
-		let output = style.escape_inner_reset_sequences();
+        let expected = String::from("hello world !");
+        let output = style.escape_inner_reset_sequences();
 
-		assert_eq!(expected, output);
-	}
+        assert_eq!(expected, output);
+    }
 
-	#[test]
-	fn escape_reset_sequence_spec_should_replace_inner_reset_sequence_with_current_style() {
-		let input = format!("start {} end", String::from("hello world !").red());
-		let style = input.blue();
+    #[test]
+    fn escape_reset_sequence_spec_should_replace_inner_reset_sequence_with_current_style() {
+        let input = format!("start {} end", String::from("hello world !").red());
+        let style = input.blue();
 
-		let output = style.escape_inner_reset_sequences();
-		let blue = "\x1B[34m";
-		let red = "\x1B[31m";
-		let reset = "\x1B[0m";
-		let expected = format!("start {}hello world !{}{} end", red, reset, blue);
-		assert_eq!(expected, output);
-	}
+        let output = style.escape_inner_reset_sequences();
+        let blue = "\x1B[34m";
+        let red = "\x1B[31m";
+        let reset = "\x1B[0m";
+        let expected = format!("start {}hello world !{}{} end", red, reset, blue);
+        assert_eq!(expected, output);
+    }
 
-	#[test]
-	fn escape_reset_sequence_spec_should_replace_multiple_inner_reset_sequences_with_current_style()
-	{
-		let italic_str = String::from("yo").italic();
-		let input = format!(
-			"start 1:{} 2:{} 3:{} end",
-			italic_str, italic_str, italic_str
-		);
-		let style = input.blue();
+    #[test]
+    fn escape_reset_sequence_spec_should_replace_multiple_inner_reset_sequences_with_current_style()
+    {
+        let italic_str = String::from("yo").italic();
+        let input = format!(
+            "start 1:{} 2:{} 3:{} end",
+            italic_str, italic_str, italic_str
+        );
+        let style = input.blue();
 
-		let output = style.escape_inner_reset_sequences();
-		let blue = "\x1B[34m";
-		let italic = "\x1B[3m";
-		let reset = "\x1B[0m";
-		let expected = format!(
-			"start 1:{}yo{}{} 2:{}yo{}{} 3:{}yo{}{} end",
-			italic, reset, blue, italic, reset, blue, italic, reset, blue
-		);
+        let output = style.escape_inner_reset_sequences();
+        let blue = "\x1B[34m";
+        let italic = "\x1B[3m";
+        let reset = "\x1B[0m";
+        let expected = format!(
+            "start 1:{}yo{}{} 2:{}yo{}{} 3:{}yo{}{} end",
+            italic, reset, blue, italic, reset, blue, italic, reset, blue
+        );
 
-		println!("first: {}\nsecond: {}", expected, output);
+        println!("first: {}\nsecond: {}", expected, output);
 
-		assert_eq!(expected, output);
-	}
+        assert_eq!(expected, output);
+    }
 
-	#[test]
-	fn color_fn() {
-		assert_eq!("blue".blue(), "blue".color("blue"))
-	}
+    #[test]
+    fn color_fn() {
+        assert_eq!("blue".blue(), "blue".color("blue"))
+    }
 
-	#[test]
-	fn on_color_fn() {
-		assert_eq!("blue".on_blue(), "blue".on_color("blue"))
-	}
+    #[test]
+    fn on_color_fn() {
+        assert_eq!("blue".on_blue(), "blue".on_color("blue"))
+    }
 
-	#[test]
-	fn bright_color_fn() {
-		assert_eq!("blue".bright_blue(), "blue".color("bright blue"))
-	}
+    #[test]
+    fn bright_color_fn() {
+        assert_eq!("blue".bright_blue(), "blue".color("bright blue"))
+    }
 
-	#[test]
-	fn on_bright_color_fn() {
-		assert_eq!("blue".on_bright_blue(), "blue".on_color("bright blue"))
-	}
+    #[test]
+    fn on_bright_color_fn() {
+        assert_eq!("blue".on_bright_blue(), "blue".on_color("bright blue"))
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 
 #[macro_use]
 extern crate lazy_static;
+#[cfg(windows)]
 extern crate winconsole;
 
 #[cfg(test)]
@@ -45,10 +46,10 @@ use std::string::String;
 /// A string that may have color and/or style applied to it.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ColoredString {
-    input: String,
-    fgcolor: Option<Color>,
-    bgcolor: Option<Color>,
-    style: style::Style,
+	input: String,
+	fgcolor: Option<Color>,
+	bgcolor: Option<Color>,
+	style: style::Style,
 }
 
 /// The trait that enables something to be given color.
@@ -56,173 +57,174 @@ pub struct ColoredString {
 /// You can use `colored` effectively simply by importing this trait
 /// and then using its methods on `String` and `&str`.
 pub trait Colorize {
-    // Font Colors
-    fn black(self) -> ColoredString;
-    fn red(self) -> ColoredString;
-    fn green(self) -> ColoredString;
-    fn yellow(self) -> ColoredString;
-    fn blue(self) -> ColoredString;
-    fn magenta(self) -> ColoredString;
-    fn purple(self) -> ColoredString;
-    fn cyan(self) -> ColoredString;
-    fn white(self) -> ColoredString;
-    fn bright_black(self) -> ColoredString;
-    fn bright_red(self) -> ColoredString;
-    fn bright_green(self) -> ColoredString;
-    fn bright_yellow(self) -> ColoredString;
-    fn bright_blue(self) -> ColoredString;
-    fn bright_magenta(self) -> ColoredString;
-    fn bright_purple(self) -> ColoredString;
-    fn bright_cyan(self) -> ColoredString;
-    fn bright_white(self) -> ColoredString;
-    fn color<S: Into<Color>>(self, color: S) -> ColoredString;
-    // Background Colors
-    fn on_black(self) -> ColoredString;
-    fn on_red(self) -> ColoredString;
-    fn on_green(self) -> ColoredString;
-    fn on_yellow(self) -> ColoredString;
-    fn on_blue(self) -> ColoredString;
-    fn on_magenta(self) -> ColoredString;
-    fn on_purple(self) -> ColoredString;
-    fn on_cyan(self) -> ColoredString;
-    fn on_white(self) -> ColoredString;
-    fn on_bright_black(self) -> ColoredString;
-    fn on_bright_red(self) -> ColoredString;
-    fn on_bright_green(self) -> ColoredString;
-    fn on_bright_yellow(self) -> ColoredString;
-    fn on_bright_blue(self) -> ColoredString;
-    fn on_bright_magenta(self) -> ColoredString;
-    fn on_bright_purple(self) -> ColoredString;
-    fn on_bright_cyan(self) -> ColoredString;
-    fn on_bright_white(self) -> ColoredString;
-    fn on_color<S: Into<Color>>(self, color: S) -> ColoredString;
-    // Styles
-    fn clear(self) -> ColoredString;
-    fn normal(self) -> ColoredString;
-    fn bold(self) -> ColoredString;
-    fn dimmed(self) -> ColoredString;
-    fn italic(self) -> ColoredString;
-    fn underline(self) -> ColoredString;
-    fn blink(self) -> ColoredString;
-    /// Historical name of `Colorize::reversed`. May be removed in a future version. Please use
-    /// `Colorize::reversed` instead
-    fn reverse(self) -> ColoredString;
-    /// This should be preferred to `Colorize::reverse`.
-    fn reversed(self) -> ColoredString;
-    fn hidden(self) -> ColoredString;
-    fn strikethrough(self) -> ColoredString;
+	// Font Colors
+	fn black(self) -> ColoredString;
+	fn red(self) -> ColoredString;
+	fn green(self) -> ColoredString;
+	fn yellow(self) -> ColoredString;
+	fn blue(self) -> ColoredString;
+	fn magenta(self) -> ColoredString;
+	fn purple(self) -> ColoredString;
+	fn cyan(self) -> ColoredString;
+	fn white(self) -> ColoredString;
+	fn bright_black(self) -> ColoredString;
+	fn bright_red(self) -> ColoredString;
+	fn bright_green(self) -> ColoredString;
+	fn bright_yellow(self) -> ColoredString;
+	fn bright_blue(self) -> ColoredString;
+	fn bright_magenta(self) -> ColoredString;
+	fn bright_purple(self) -> ColoredString;
+	fn bright_cyan(self) -> ColoredString;
+	fn bright_white(self) -> ColoredString;
+	fn color<S: Into<Color>>(self, color: S) -> ColoredString;
+	// Background Colors
+	fn on_black(self) -> ColoredString;
+	fn on_red(self) -> ColoredString;
+	fn on_green(self) -> ColoredString;
+	fn on_yellow(self) -> ColoredString;
+	fn on_blue(self) -> ColoredString;
+	fn on_magenta(self) -> ColoredString;
+	fn on_purple(self) -> ColoredString;
+	fn on_cyan(self) -> ColoredString;
+	fn on_white(self) -> ColoredString;
+	fn on_bright_black(self) -> ColoredString;
+	fn on_bright_red(self) -> ColoredString;
+	fn on_bright_green(self) -> ColoredString;
+	fn on_bright_yellow(self) -> ColoredString;
+	fn on_bright_blue(self) -> ColoredString;
+	fn on_bright_magenta(self) -> ColoredString;
+	fn on_bright_purple(self) -> ColoredString;
+	fn on_bright_cyan(self) -> ColoredString;
+	fn on_bright_white(self) -> ColoredString;
+	fn on_color<S: Into<Color>>(self, color: S) -> ColoredString;
+	// Styles
+	fn clear(self) -> ColoredString;
+	fn normal(self) -> ColoredString;
+	fn bold(self) -> ColoredString;
+	fn dimmed(self) -> ColoredString;
+	fn italic(self) -> ColoredString;
+	fn underline(self) -> ColoredString;
+	fn blink(self) -> ColoredString;
+	/// Historical name of `Colorize::reversed`. May be removed in a future version. Please use
+	/// `Colorize::reversed` instead
+	fn reverse(self) -> ColoredString;
+	/// This should be preferred to `Colorize::reverse`.
+	fn reversed(self) -> ColoredString;
+	fn hidden(self) -> ColoredString;
+	fn strikethrough(self) -> ColoredString;
 }
 
 impl ColoredString {
-    pub fn is_plain(&self) -> bool {
-        (self.bgcolor.is_none() && self.fgcolor.is_none() && self.style == style::CLEAR)
-    }
+	pub fn is_plain(&self) -> bool {
+		(self.bgcolor.is_none() && self.fgcolor.is_none() && self.style == style::CLEAR)
+	}
 
-    #[cfg(not(feature = "no-color"))]
-    fn has_colors(&self) -> bool {
-        use control;
+	#[cfg(not(feature = "no-color"))]
+	fn has_colors(&self) -> bool {
+		use control;
 
-        control::SHOULD_COLORIZE.should_colorize()
-    }
+		control::SHOULD_COLORIZE.should_colorize()
+	}
 
-    #[cfg(feature = "no-color")]
-    fn has_colors(&self) -> bool {
-        false
-    }
+	#[cfg(feature = "no-color")]
+	fn has_colors(&self) -> bool {
+		false
+	}
 
-    fn compute_style(&self) -> String {
-        if !self.has_colors() || self.is_plain() {
-            return String::new();
-        }
+	fn compute_style(&self) -> String {
+		if !self.has_colors() || self.is_plain() {
+			return String::new();
+		}
 
-        let mut res = String::from("\x1B[");
-        let mut has_wrote = if self.style != style::CLEAR {
-            res.push_str(&self.style.to_str());
-            true
-        } else {
-            false
-        };
+		let mut res = String::from("\x1B[");
+		let mut has_wrote = if self.style != style::CLEAR {
+			res.push_str(&self.style.to_str());
+			true
+		} else {
+			false
+		};
 
-        if let Some(ref bgcolor) = self.bgcolor {
-            if has_wrote {
-                res.push(';');
-            }
+		if let Some(ref bgcolor) = self.bgcolor {
+			if has_wrote {
+				res.push(';');
+			}
 
-            res.push_str(bgcolor.to_bg_str());
-            has_wrote = true;
-        }
+			res.push_str(bgcolor.to_bg_str());
+			has_wrote = true;
+		}
 
-        if let Some(ref fgcolor) = self.fgcolor {
-            if has_wrote {
-                res.push(';');
-            }
+		if let Some(ref fgcolor) = self.fgcolor {
+			if has_wrote {
+				res.push(';');
+			}
 
-            res.push_str(fgcolor.to_fg_str());
-        }
+			res.push_str(fgcolor.to_fg_str());
+		}
 
-        res.push('m');
-        res
-    }
+		res.push('m');
+		res
+	}
 
-    fn escape_inner_reset_sequences(&self) -> String {
-        if !self.has_colors() || self.is_plain() {
-            return self.input.clone();
-        }
+	fn escape_inner_reset_sequences(&self) -> String {
+		if !self.has_colors() || self.is_plain() {
+			return self.input.clone();
+		}
 
-        // TODO: BoyScoutRule
-        let reset = "\x1B[0m";
-        let style = self.compute_style();
-        let matches: Vec<usize> = self.input
-            .match_indices(reset)
-            .map(|(idx, _)| idx)
-            .collect();
+		// TODO: BoyScoutRule
+		let reset = "\x1B[0m";
+		let style = self.compute_style();
+		let matches: Vec<usize> = self
+			.input
+			.match_indices(reset)
+			.map(|(idx, _)| idx)
+			.collect();
 
-        let mut idx_in_matches = 0;
-        let mut input = self.input.clone();
-        input.reserve(matches.len() * style.len());
+		let mut idx_in_matches = 0;
+		let mut input = self.input.clone();
+		input.reserve(matches.len() * style.len());
 
-        for offset in matches {
-            // shift the offset to the end of the reset sequence and take in account
-            // the number of matches we have escaped (which shift the index to insert)
-            let mut offset = offset + reset.len() + idx_in_matches * style.len();
+		for offset in matches {
+			// shift the offset to the end of the reset sequence and take in account
+			// the number of matches we have escaped (which shift the index to insert)
+			let mut offset = offset + reset.len() + idx_in_matches * style.len();
 
-            for cchar in style.chars() {
-                input.insert(offset, cchar);
-                offset += 1;
-            }
+			for cchar in style.chars() {
+				input.insert(offset, cchar);
+				offset += 1;
+			}
 
-            idx_in_matches += 1;
-        }
+			idx_in_matches += 1;
+		}
 
-        input
-    }
+		input
+	}
 }
 
 impl Default for ColoredString {
-    fn default() -> Self {
-        ColoredString {
-            input: String::default(),
-            fgcolor: None,
-            bgcolor: None,
-            style: style::CLEAR,
-        }
-    }
+	fn default() -> Self {
+		ColoredString {
+			input: String::default(),
+			fgcolor: None,
+			bgcolor: None,
+			style: style::CLEAR,
+		}
+	}
 }
 
 impl Deref for ColoredString {
-    type Target = str;
-    fn deref(&self) -> &str {
-        &self.input
-    }
+	type Target = str;
+	fn deref(&self) -> &str {
+		&self.input
+	}
 }
 
 impl<'a> From<&'a str> for ColoredString {
-    fn from(s: &'a str) -> Self {
-        ColoredString {
-            input: String::from(s),
-            ..ColoredString::default()
-        }
-    }
+	fn from(s: &'a str) -> Self {
+		ColoredString {
+			input: String::from(s),
+			..ColoredString::default()
+		}
+	}
 }
 
 macro_rules! def_color {
@@ -247,91 +249,91 @@ macro_rules! def_style {
 }
 
 impl Colorize for ColoredString {
-    def_color!(fgcolor: black => Color::Black);
-    fn red(self) -> ColoredString {
-        self.color(Color::Red)
-    }
-    def_color!(fgcolor: green => Color::Green);
-    def_color!(fgcolor: yellow => Color::Yellow);
-    def_color!(fgcolor: blue => Color::Blue);
-    def_color!(fgcolor: magenta => Color::Magenta);
-    def_color!(fgcolor: purple => Color::Magenta);
-    def_color!(fgcolor: cyan => Color::Cyan);
-    def_color!(fgcolor: white => Color::White);
-    def_color!(fgcolor: bright_black => Color::BrightBlack);
-    fn bright_red(self) -> ColoredString {
-        self.color(Color::BrightRed)
-    }
-    def_color!(fgcolor: bright_green => Color::BrightGreen);
-    def_color!(fgcolor: bright_yellow => Color::BrightYellow);
-    def_color!(fgcolor: bright_blue => Color::BrightBlue);
-    def_color!(fgcolor: bright_magenta => Color::BrightMagenta);
-    def_color!(fgcolor: bright_purple => Color::BrightMagenta);
-    def_color!(fgcolor: bright_cyan => Color::BrightCyan);
-    def_color!(fgcolor: bright_white => Color::BrightWhite);
+	def_color!(fgcolor: black => Color::Black);
+	fn red(self) -> ColoredString {
+		self.color(Color::Red)
+	}
+	def_color!(fgcolor: green => Color::Green);
+	def_color!(fgcolor: yellow => Color::Yellow);
+	def_color!(fgcolor: blue => Color::Blue);
+	def_color!(fgcolor: magenta => Color::Magenta);
+	def_color!(fgcolor: purple => Color::Magenta);
+	def_color!(fgcolor: cyan => Color::Cyan);
+	def_color!(fgcolor: white => Color::White);
+	def_color!(fgcolor: bright_black => Color::BrightBlack);
+	fn bright_red(self) -> ColoredString {
+		self.color(Color::BrightRed)
+	}
+	def_color!(fgcolor: bright_green => Color::BrightGreen);
+	def_color!(fgcolor: bright_yellow => Color::BrightYellow);
+	def_color!(fgcolor: bright_blue => Color::BrightBlue);
+	def_color!(fgcolor: bright_magenta => Color::BrightMagenta);
+	def_color!(fgcolor: bright_purple => Color::BrightMagenta);
+	def_color!(fgcolor: bright_cyan => Color::BrightCyan);
+	def_color!(fgcolor: bright_white => Color::BrightWhite);
 
-    fn color<S: Into<Color>>(self, color: S) -> ColoredString {
-        ColoredString {
-            fgcolor: Some(color.into()),
-            ..self
-        }
-    }
+	fn color<S: Into<Color>>(self, color: S) -> ColoredString {
+		ColoredString {
+			fgcolor: Some(color.into()),
+			..self
+		}
+	}
 
-    def_color!(bgcolor: on_black => Color::Black);
-    fn on_red(self) -> ColoredString {
-        ColoredString {
-            bgcolor: Some(Color::Red),
-            ..self
-        }
-    }
-    def_color!(bgcolor: on_green => Color::Green);
-    def_color!(bgcolor: on_yellow => Color::Yellow);
-    def_color!(bgcolor: on_blue => Color::Blue);
-    def_color!(bgcolor: on_magenta => Color::Magenta);
-    def_color!(bgcolor: on_purple => Color::Magenta);
-    def_color!(bgcolor: on_cyan => Color::Cyan);
-    def_color!(bgcolor: on_white => Color::White);
+	def_color!(bgcolor: on_black => Color::Black);
+	fn on_red(self) -> ColoredString {
+		ColoredString {
+			bgcolor: Some(Color::Red),
+			..self
+		}
+	}
+	def_color!(bgcolor: on_green => Color::Green);
+	def_color!(bgcolor: on_yellow => Color::Yellow);
+	def_color!(bgcolor: on_blue => Color::Blue);
+	def_color!(bgcolor: on_magenta => Color::Magenta);
+	def_color!(bgcolor: on_purple => Color::Magenta);
+	def_color!(bgcolor: on_cyan => Color::Cyan);
+	def_color!(bgcolor: on_white => Color::White);
 
-    def_color!(bgcolor: on_bright_black => Color::BrightBlack);
-    fn on_bright_red(self) -> ColoredString {
-        ColoredString {
-            bgcolor: Some(Color::BrightRed),
-            ..self
-        }
-    }
-    def_color!(bgcolor: on_bright_green => Color::BrightGreen);
-    def_color!(bgcolor: on_bright_yellow => Color::BrightYellow);
-    def_color!(bgcolor: on_bright_blue => Color::BrightBlue);
-    def_color!(bgcolor: on_bright_magenta => Color::BrightMagenta);
-    def_color!(bgcolor: on_bright_purple => Color::BrightMagenta);
-    def_color!(bgcolor: on_bright_cyan => Color::BrightCyan);
-    def_color!(bgcolor: on_bright_white => Color::BrightWhite);
+	def_color!(bgcolor: on_bright_black => Color::BrightBlack);
+	fn on_bright_red(self) -> ColoredString {
+		ColoredString {
+			bgcolor: Some(Color::BrightRed),
+			..self
+		}
+	}
+	def_color!(bgcolor: on_bright_green => Color::BrightGreen);
+	def_color!(bgcolor: on_bright_yellow => Color::BrightYellow);
+	def_color!(bgcolor: on_bright_blue => Color::BrightBlue);
+	def_color!(bgcolor: on_bright_magenta => Color::BrightMagenta);
+	def_color!(bgcolor: on_bright_purple => Color::BrightMagenta);
+	def_color!(bgcolor: on_bright_cyan => Color::BrightCyan);
+	def_color!(bgcolor: on_bright_white => Color::BrightWhite);
 
-    fn on_color<S: Into<Color>>(self, color: S) -> ColoredString {
-        ColoredString {
-            bgcolor: Some(color.into()),
-            ..self
-        }
-    }
+	fn on_color<S: Into<Color>>(self, color: S) -> ColoredString {
+		ColoredString {
+			bgcolor: Some(color.into()),
+			..self
+		}
+	}
 
-    fn clear(self) -> ColoredString {
-        ColoredString {
-            input: self.input,
-            ..ColoredString::default()
-        }
-    }
-    fn normal(self) -> ColoredString {
-        self.clear()
-    }
-    def_style!(bold, style::Styles::Bold);
-    def_style!(dimmed, style::Styles::Dimmed);
-    def_style!(italic, style::Styles::Italic);
-    def_style!(underline, style::Styles::Underline);
-    def_style!(blink, style::Styles::Blink);
-    def_style!(reverse, style::Styles::Reversed);
-    def_style!(reversed, style::Styles::Reversed);
-    def_style!(hidden, style::Styles::Hidden);
-    def_style!(strikethrough, style::Styles::Strikethrough);
+	fn clear(self) -> ColoredString {
+		ColoredString {
+			input: self.input,
+			..ColoredString::default()
+		}
+	}
+	fn normal(self) -> ColoredString {
+		self.clear()
+	}
+	def_style!(bold, style::Styles::Bold);
+	def_style!(dimmed, style::Styles::Dimmed);
+	def_style!(italic, style::Styles::Italic);
+	def_style!(underline, style::Styles::Underline);
+	def_style!(blink, style::Styles::Blink);
+	def_style!(reverse, style::Styles::Reversed);
+	def_style!(reversed, style::Styles::Reversed);
+	def_style!(hidden, style::Styles::Hidden);
+	def_style!(strikethrough, style::Styles::Strikethrough);
 }
 
 macro_rules! def_str_color {
@@ -359,328 +361,328 @@ macro_rules! def_str_style {
 }
 
 impl<'a> Colorize for &'a str {
-    def_str_color!(fgcolor: black => Color::Black);
-    fn red(self) -> ColoredString {
-        ColoredString {
-            input: String::from(self),
-            fgcolor: Some(Color::Red),
-            ..ColoredString::default()
-        }
-    }
-    def_str_color!(fgcolor: green => Color::Green);
-    def_str_color!(fgcolor: yellow => Color::Yellow);
-    def_str_color!(fgcolor: blue => Color::Blue);
-    def_str_color!(fgcolor: magenta => Color::Magenta);
-    def_str_color!(fgcolor: purple => Color::Magenta);
-    def_str_color!(fgcolor: cyan => Color::Cyan);
-    def_str_color!(fgcolor: white => Color::White);
+	def_str_color!(fgcolor: black => Color::Black);
+	fn red(self) -> ColoredString {
+		ColoredString {
+			input: String::from(self),
+			fgcolor: Some(Color::Red),
+			..ColoredString::default()
+		}
+	}
+	def_str_color!(fgcolor: green => Color::Green);
+	def_str_color!(fgcolor: yellow => Color::Yellow);
+	def_str_color!(fgcolor: blue => Color::Blue);
+	def_str_color!(fgcolor: magenta => Color::Magenta);
+	def_str_color!(fgcolor: purple => Color::Magenta);
+	def_str_color!(fgcolor: cyan => Color::Cyan);
+	def_str_color!(fgcolor: white => Color::White);
 
-    def_str_color!(fgcolor: bright_black => Color::BrightBlack);
-    fn bright_red(self) -> ColoredString {
-        ColoredString {
-            input: String::from(self),
-            fgcolor: Some(Color::BrightRed),
-            ..ColoredString::default()
-        }
-    }
-    def_str_color!(fgcolor: bright_green => Color::BrightGreen);
-    def_str_color!(fgcolor: bright_yellow => Color::BrightYellow);
-    def_str_color!(fgcolor: bright_blue => Color::BrightBlue);
-    def_str_color!(fgcolor: bright_magenta => Color::BrightMagenta);
-    def_str_color!(fgcolor: bright_purple => Color::BrightMagenta);
-    def_str_color!(fgcolor: bright_cyan => Color::BrightCyan);
-    def_str_color!(fgcolor: bright_white => Color::BrightWhite);
+	def_str_color!(fgcolor: bright_black => Color::BrightBlack);
+	fn bright_red(self) -> ColoredString {
+		ColoredString {
+			input: String::from(self),
+			fgcolor: Some(Color::BrightRed),
+			..ColoredString::default()
+		}
+	}
+	def_str_color!(fgcolor: bright_green => Color::BrightGreen);
+	def_str_color!(fgcolor: bright_yellow => Color::BrightYellow);
+	def_str_color!(fgcolor: bright_blue => Color::BrightBlue);
+	def_str_color!(fgcolor: bright_magenta => Color::BrightMagenta);
+	def_str_color!(fgcolor: bright_purple => Color::BrightMagenta);
+	def_str_color!(fgcolor: bright_cyan => Color::BrightCyan);
+	def_str_color!(fgcolor: bright_white => Color::BrightWhite);
 
-    fn color<S: Into<Color>>(self, color: S) -> ColoredString {
-        ColoredString {
-            fgcolor: Some(color.into()),
-            input: String::from(self),
-            ..ColoredString::default()
-        }
-    }
+	fn color<S: Into<Color>>(self, color: S) -> ColoredString {
+		ColoredString {
+			fgcolor: Some(color.into()),
+			input: String::from(self),
+			..ColoredString::default()
+		}
+	}
 
-    def_str_color!(bgcolor: on_black => Color::Black);
-    fn on_red(self) -> ColoredString {
-        ColoredString {
-            input: String::from(self),
-            bgcolor: Some(Color::Red),
-            ..ColoredString::default()
-        }
-    }
-    def_str_color!(bgcolor: on_green => Color::Green);
-    def_str_color!(bgcolor: on_yellow => Color::Yellow);
-    def_str_color!(bgcolor: on_blue => Color::Blue);
-    def_str_color!(bgcolor: on_magenta => Color::Magenta);
-    def_str_color!(bgcolor: on_purple => Color::Magenta);
-    def_str_color!(bgcolor: on_cyan => Color::Cyan);
-    def_str_color!(bgcolor: on_white => Color::White);
+	def_str_color!(bgcolor: on_black => Color::Black);
+	fn on_red(self) -> ColoredString {
+		ColoredString {
+			input: String::from(self),
+			bgcolor: Some(Color::Red),
+			..ColoredString::default()
+		}
+	}
+	def_str_color!(bgcolor: on_green => Color::Green);
+	def_str_color!(bgcolor: on_yellow => Color::Yellow);
+	def_str_color!(bgcolor: on_blue => Color::Blue);
+	def_str_color!(bgcolor: on_magenta => Color::Magenta);
+	def_str_color!(bgcolor: on_purple => Color::Magenta);
+	def_str_color!(bgcolor: on_cyan => Color::Cyan);
+	def_str_color!(bgcolor: on_white => Color::White);
 
-    def_str_color!(bgcolor: on_bright_black => Color::BrightBlack);
-    fn on_bright_red(self) -> ColoredString {
-        ColoredString {
-            input: String::from(self),
-            bgcolor: Some(Color::BrightRed),
-            ..ColoredString::default()
-        }
-    }
-    def_str_color!(bgcolor: on_bright_green => Color::BrightGreen);
-    def_str_color!(bgcolor: on_bright_yellow => Color::BrightYellow);
-    def_str_color!(bgcolor: on_bright_blue => Color::BrightBlue);
-    def_str_color!(bgcolor: on_bright_magenta => Color::BrightMagenta);
-    def_str_color!(bgcolor: on_bright_purple => Color::BrightMagenta);
-    def_str_color!(bgcolor: on_bright_cyan => Color::BrightCyan);
-    def_str_color!(bgcolor: on_bright_white => Color::BrightWhite);
+	def_str_color!(bgcolor: on_bright_black => Color::BrightBlack);
+	fn on_bright_red(self) -> ColoredString {
+		ColoredString {
+			input: String::from(self),
+			bgcolor: Some(Color::BrightRed),
+			..ColoredString::default()
+		}
+	}
+	def_str_color!(bgcolor: on_bright_green => Color::BrightGreen);
+	def_str_color!(bgcolor: on_bright_yellow => Color::BrightYellow);
+	def_str_color!(bgcolor: on_bright_blue => Color::BrightBlue);
+	def_str_color!(bgcolor: on_bright_magenta => Color::BrightMagenta);
+	def_str_color!(bgcolor: on_bright_purple => Color::BrightMagenta);
+	def_str_color!(bgcolor: on_bright_cyan => Color::BrightCyan);
+	def_str_color!(bgcolor: on_bright_white => Color::BrightWhite);
 
-    fn on_color<S: Into<Color>>(self, color: S) -> ColoredString {
-        ColoredString {
-            bgcolor: Some(color.into()),
-            input: String::from(self),
-            ..ColoredString::default()
-        }
-    }
+	fn on_color<S: Into<Color>>(self, color: S) -> ColoredString {
+		ColoredString {
+			bgcolor: Some(color.into()),
+			input: String::from(self),
+			..ColoredString::default()
+		}
+	}
 
-    fn clear(self) -> ColoredString {
-        ColoredString {
-            input: String::from(self),
-            style: style::CLEAR,
-            ..ColoredString::default()
-        }
-    }
-    fn normal(self) -> ColoredString {
-        self.clear()
-    }
-    def_str_style!(bold, style::Styles::Bold);
-    def_str_style!(dimmed, style::Styles::Dimmed);
-    def_str_style!(italic, style::Styles::Italic);
-    def_str_style!(underline, style::Styles::Underline);
-    def_str_style!(blink, style::Styles::Blink);
-    def_str_style!(reverse, style::Styles::Reversed);
-    def_str_style!(reversed, style::Styles::Reversed);
-    def_str_style!(hidden, style::Styles::Hidden);
-    def_str_style!(strikethrough, style::Styles::Strikethrough);
+	fn clear(self) -> ColoredString {
+		ColoredString {
+			input: String::from(self),
+			style: style::CLEAR,
+			..ColoredString::default()
+		}
+	}
+	fn normal(self) -> ColoredString {
+		self.clear()
+	}
+	def_str_style!(bold, style::Styles::Bold);
+	def_str_style!(dimmed, style::Styles::Dimmed);
+	def_str_style!(italic, style::Styles::Italic);
+	def_str_style!(underline, style::Styles::Underline);
+	def_str_style!(blink, style::Styles::Blink);
+	def_str_style!(reverse, style::Styles::Reversed);
+	def_str_style!(reversed, style::Styles::Reversed);
+	def_str_style!(hidden, style::Styles::Hidden);
+	def_str_style!(strikethrough, style::Styles::Strikethrough);
 }
 
 impl fmt::Display for ColoredString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if !self.has_colors() || self.is_plain() {
-            return (<String as fmt::Display>::fmt(&self.input, f));
-        }
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		if !self.has_colors() || self.is_plain() {
+			return (<String as fmt::Display>::fmt(&self.input, f));
+		}
 
-        // XXX: see tests. Useful when nesting colored strings
-        let escaped_input = self.escape_inner_reset_sequences();
+		// XXX: see tests. Useful when nesting colored strings
+		let escaped_input = self.escape_inner_reset_sequences();
 
-        try!(f.write_str(&self.compute_style()));
-        try!(<String as fmt::Display>::fmt(&escaped_input, f));
-        try!(f.write_str("\x1B[0m"));
-        Ok(())
-    }
+		try!(f.write_str(&self.compute_style()));
+		try!(<String as fmt::Display>::fmt(&escaped_input, f));
+		try!(f.write_str("\x1B[0m"));
+		Ok(())
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn formatting() {
-        // respect the formatting. Escape sequence add some padding so >= 40
-        assert!(format!("{:40}", "".blue()).len() >= 40);
-        // both should be truncated to 1 char before coloring
-        assert_eq!(
-            format!("{:1.1}", "toto".blue()).len(),
-            format!("{:1.1}", "1".blue()).len()
-        )
-    }
+	#[test]
+	fn formatting() {
+		// respect the formatting. Escape sequence add some padding so >= 40
+		assert!(format!("{:40}", "".blue()).len() >= 40);
+		// both should be truncated to 1 char before coloring
+		assert_eq!(
+			format!("{:1.1}", "toto".blue()).len(),
+			format!("{:1.1}", "1".blue()).len()
+		)
+	}
 
-    #[test]
-    fn it_works() {
-        let toto = "toto";
-        println!("{}", toto.red());
-        println!("{}", String::from(toto).red());
-        println!("{}", toto.blue());
+	#[test]
+	fn it_works() {
+		let toto = "toto";
+		println!("{}", toto.red());
+		println!("{}", String::from(toto).red());
+		println!("{}", toto.blue());
 
-        println!("blue style ****");
-        println!("{}", toto.bold());
-        println!("{}", "yeah ! Red bold !".red().bold());
-        println!("{}", "yeah ! Yellow bold !".bold().yellow());
-        println!("{}", toto.bold().blue());
-        println!("{}", toto.blue().bold());
-        println!("{}", toto.blue().bold().underline());
-        println!("{}", toto.blue().italic());
-        println!("******");
-        println!("test clearing");
-        println!("{}", "red cleared".red().clear());
-        println!("{}", "bold cyan cleared".bold().cyan().clear());
-        println!("******");
-        println!("Bg tests");
-        println!("{}", toto.green().on_blue());
-        println!("{}", toto.on_magenta().yellow());
-        println!("{}", toto.purple().on_yellow());
-        println!("{}", toto.magenta().on_white());
-        println!("{}", toto.cyan().on_green());
-        println!("{}", toto.black().on_white());
-        println!("******");
-        println!("{}", toto.green());
-        println!("{}", toto.yellow());
-        println!("{}", toto.purple());
-        println!("{}", toto.magenta());
-        println!("{}", toto.cyan());
-        println!("{}", toto.white());
-        println!("{}", toto.white().red().blue().green());
-        // uncomment to see term output
-        // assert!(false)
-    }
+		println!("blue style ****");
+		println!("{}", toto.bold());
+		println!("{}", "yeah ! Red bold !".red().bold());
+		println!("{}", "yeah ! Yellow bold !".bold().yellow());
+		println!("{}", toto.bold().blue());
+		println!("{}", toto.blue().bold());
+		println!("{}", toto.blue().bold().underline());
+		println!("{}", toto.blue().italic());
+		println!("******");
+		println!("test clearing");
+		println!("{}", "red cleared".red().clear());
+		println!("{}", "bold cyan cleared".bold().cyan().clear());
+		println!("******");
+		println!("Bg tests");
+		println!("{}", toto.green().on_blue());
+		println!("{}", toto.on_magenta().yellow());
+		println!("{}", toto.purple().on_yellow());
+		println!("{}", toto.magenta().on_white());
+		println!("{}", toto.cyan().on_green());
+		println!("{}", toto.black().on_white());
+		println!("******");
+		println!("{}", toto.green());
+		println!("{}", toto.yellow());
+		println!("{}", toto.purple());
+		println!("{}", toto.magenta());
+		println!("{}", toto.cyan());
+		println!("{}", toto.white());
+		println!("{}", toto.white().red().blue().green());
+		// uncomment to see term output
+		// assert!(false)
+	}
 
-    #[test]
-    fn compute_style_empty_string() {
-        assert_eq!("", "".clear().compute_style());
-    }
+	#[test]
+	fn compute_style_empty_string() {
+		assert_eq!("", "".clear().compute_style());
+	}
 
-    #[test]
-    fn compute_style_simple_fg_blue() {
-        let blue = "\x1B[34m";
+	#[test]
+	fn compute_style_simple_fg_blue() {
+		let blue = "\x1B[34m";
 
-        assert_eq!(blue, "".blue().compute_style());
-    }
+		assert_eq!(blue, "".blue().compute_style());
+	}
 
-    #[test]
-    fn compute_style_simple_bg_blue() {
-        let on_blue = "\x1B[44m";
+	#[test]
+	fn compute_style_simple_bg_blue() {
+		let on_blue = "\x1B[44m";
 
-        assert_eq!(on_blue, "".on_blue().compute_style());
-    }
+		assert_eq!(on_blue, "".on_blue().compute_style());
+	}
 
-    #[test]
-    fn compute_style_blue_on_blue() {
-        let blue_on_blue = "\x1B[44;34m";
+	#[test]
+	fn compute_style_blue_on_blue() {
+		let blue_on_blue = "\x1B[44;34m";
 
-        assert_eq!(blue_on_blue, "".blue().on_blue().compute_style());
-    }
+		assert_eq!(blue_on_blue, "".blue().on_blue().compute_style());
+	}
 
-    #[test]
-    fn compute_style_simple_fg_bright_blue() {
-        let blue = "\x1B[94m";
+	#[test]
+	fn compute_style_simple_fg_bright_blue() {
+		let blue = "\x1B[94m";
 
-        assert_eq!(blue, "".bright_blue().compute_style());
-    }
+		assert_eq!(blue, "".bright_blue().compute_style());
+	}
 
-    #[test]
-    fn compute_style_simple_bg_bright_blue() {
-        let on_blue = "\x1B[104m";
+	#[test]
+	fn compute_style_simple_bg_bright_blue() {
+		let on_blue = "\x1B[104m";
 
-        assert_eq!(on_blue, "".on_bright_blue().compute_style());
-    }
+		assert_eq!(on_blue, "".on_bright_blue().compute_style());
+	}
 
-    #[test]
-    fn compute_style_bright_blue_on_bright_blue() {
-        let blue_on_blue = "\x1B[104;94m";
+	#[test]
+	fn compute_style_bright_blue_on_bright_blue() {
+		let blue_on_blue = "\x1B[104;94m";
 
-        assert_eq!(
-            blue_on_blue,
-            "".bright_blue().on_bright_blue().compute_style()
-        );
-    }
+		assert_eq!(
+			blue_on_blue,
+			"".bright_blue().on_bright_blue().compute_style()
+		);
+	}
 
-    #[test]
-    fn compute_style_simple_bold() {
-        let bold = "\x1B[1m";
+	#[test]
+	fn compute_style_simple_bold() {
+		let bold = "\x1B[1m";
 
-        assert_eq!(bold, "".bold().compute_style());
-    }
+		assert_eq!(bold, "".bold().compute_style());
+	}
 
-    #[test]
-    fn compute_style_blue_bold() {
-        let blue_bold = "\x1B[1;34m";
+	#[test]
+	fn compute_style_blue_bold() {
+		let blue_bold = "\x1B[1;34m";
 
-        assert_eq!(blue_bold, "".blue().bold().compute_style());
-    }
+		assert_eq!(blue_bold, "".blue().bold().compute_style());
+	}
 
-    #[test]
-    fn compute_style_blue_bold_on_blue() {
-        let blue_bold_on_blue = "\x1B[1;44;34m";
+	#[test]
+	fn compute_style_blue_bold_on_blue() {
+		let blue_bold_on_blue = "\x1B[1;44;34m";
 
-        assert_eq!(
-            blue_bold_on_blue,
-            "".blue().bold().on_blue().compute_style()
-        );
-    }
+		assert_eq!(
+			blue_bold_on_blue,
+			"".blue().bold().on_blue().compute_style()
+		);
+	}
 
-    #[test]
-    fn escape_reset_sequence_spec_should_do_nothing_on_empty_strings() {
-        let style = ColoredString::default();
-        let expected = String::new();
+	#[test]
+	fn escape_reset_sequence_spec_should_do_nothing_on_empty_strings() {
+		let style = ColoredString::default();
+		let expected = String::new();
 
-        let output = style.escape_inner_reset_sequences();
+		let output = style.escape_inner_reset_sequences();
 
-        assert_eq!(expected, output);
-    }
+		assert_eq!(expected, output);
+	}
 
-    #[test]
-    fn escape_reset_sequence_spec_should_do_nothing_on_string_with_no_reset() {
-        let style = ColoredString {
-            input: String::from("hello world !"),
-            ..ColoredString::default()
-        };
+	#[test]
+	fn escape_reset_sequence_spec_should_do_nothing_on_string_with_no_reset() {
+		let style = ColoredString {
+			input: String::from("hello world !"),
+			..ColoredString::default()
+		};
 
-        let expected = String::from("hello world !");
-        let output = style.escape_inner_reset_sequences();
+		let expected = String::from("hello world !");
+		let output = style.escape_inner_reset_sequences();
 
-        assert_eq!(expected, output);
-    }
+		assert_eq!(expected, output);
+	}
 
-    #[test]
-    fn escape_reset_sequence_spec_should_replace_inner_reset_sequence_with_current_style() {
-        let input = format!("start {} end", String::from("hello world !").red());
-        let style = input.blue();
+	#[test]
+	fn escape_reset_sequence_spec_should_replace_inner_reset_sequence_with_current_style() {
+		let input = format!("start {} end", String::from("hello world !").red());
+		let style = input.blue();
 
-        let output = style.escape_inner_reset_sequences();
-        let blue = "\x1B[34m";
-        let red = "\x1B[31m";
-        let reset = "\x1B[0m";
-        let expected = format!("start {}hello world !{}{} end", red, reset, blue);
-        assert_eq!(expected, output);
-    }
+		let output = style.escape_inner_reset_sequences();
+		let blue = "\x1B[34m";
+		let red = "\x1B[31m";
+		let reset = "\x1B[0m";
+		let expected = format!("start {}hello world !{}{} end", red, reset, blue);
+		assert_eq!(expected, output);
+	}
 
-    #[test]
-    fn escape_reset_sequence_spec_should_replace_multiple_inner_reset_sequences_with_current_style()
-    {
-        let italic_str = String::from("yo").italic();
-        let input = format!(
-            "start 1:{} 2:{} 3:{} end",
-            italic_str, italic_str, italic_str
-        );
-        let style = input.blue();
+	#[test]
+	fn escape_reset_sequence_spec_should_replace_multiple_inner_reset_sequences_with_current_style()
+	{
+		let italic_str = String::from("yo").italic();
+		let input = format!(
+			"start 1:{} 2:{} 3:{} end",
+			italic_str, italic_str, italic_str
+		);
+		let style = input.blue();
 
-        let output = style.escape_inner_reset_sequences();
-        let blue = "\x1B[34m";
-        let italic = "\x1B[3m";
-        let reset = "\x1B[0m";
-        let expected = format!(
-            "start 1:{}yo{}{} 2:{}yo{}{} 3:{}yo{}{} end",
-            italic, reset, blue, italic, reset, blue, italic, reset, blue
-        );
+		let output = style.escape_inner_reset_sequences();
+		let blue = "\x1B[34m";
+		let italic = "\x1B[3m";
+		let reset = "\x1B[0m";
+		let expected = format!(
+			"start 1:{}yo{}{} 2:{}yo{}{} 3:{}yo{}{} end",
+			italic, reset, blue, italic, reset, blue, italic, reset, blue
+		);
 
-        println!("first: {}\nsecond: {}", expected, output);
+		println!("first: {}\nsecond: {}", expected, output);
 
-        assert_eq!(expected, output);
-    }
+		assert_eq!(expected, output);
+	}
 
-    #[test]
-    fn color_fn() {
-        assert_eq!("blue".blue(), "blue".color("blue"))
-    }
+	#[test]
+	fn color_fn() {
+		assert_eq!("blue".blue(), "blue".color("blue"))
+	}
 
-    #[test]
-    fn on_color_fn() {
-        assert_eq!("blue".on_blue(), "blue".on_color("blue"))
-    }
+	#[test]
+	fn on_color_fn() {
+		assert_eq!("blue".on_blue(), "blue".on_color("blue"))
+	}
 
-    #[test]
-    fn bright_color_fn() {
-        assert_eq!("blue".bright_blue(), "blue".color("bright blue"))
-    }
+	#[test]
+	fn bright_color_fn() {
+		assert_eq!("blue".bright_blue(), "blue".color("bright blue"))
+	}
 
-    #[test]
-    fn on_bright_color_fn() {
-        assert_eq!("blue".on_bright_blue(), "blue".on_color("bright blue"))
-    }
+	#[test]
+	fn on_bright_color_fn() {
+		assert_eq!("blue".on_bright_blue(), "blue".on_color("bright blue"))
+	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 
 #[macro_use]
 extern crate lazy_static;
+extern crate winconsole;
 
 #[cfg(test)]
 extern crate rspec;


### PR DESCRIPTION
Windows 10 comes with functionality to use a [virtual terminal](https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences) which will properly colourize ansi escape codes. I have added a function `control::set_virtual_terminal(bool)` which will flag the console to use a virtual terminal. This allows correct colouring of escape codes and thus makes this crate work with Windows 10.

No flag set:

![not-coloured](https://user-images.githubusercontent.com/13831379/52910701-1739aa00-32e7-11e9-89b6-534b24040112.png)


Flag set:

![coloured](https://user-images.githubusercontent.com/13831379/52910708-26205c80-32e7-11e9-809a-f3615c4683ec.png)

The user will still have to flag to use the virtual terminal.