### PR TITLE
Make winconsole a Windows-only dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ no-color = []
 
 [dependencies]
 lazy_static = "1.2.0"
+
+[target.'cfg(windows)'.dependencies]
 winconsole = "0.10.0"
 
 [dev_dependencies]


### PR DESCRIPTION
Resolves #50.