### PR TITLE
respect tty discovery for CLICOLOR, fix handling of CLICOLOR_FORCE value of 0, fix CLICOLOR_FORCE and NO_COLOR priorities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["color", "string", "term", "ansi_term", "term-painter"]
 no-color = []
 
 [dependencies]
+atty = "0.2.11"
 lazy_static = "1.2.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 //! See [the `Colorize` trait](./trait.Colorize.html) for all the methods.
 //!
 
+extern crate atty;
 #[macro_use]
 extern crate lazy_static;
 #[cfg(windows)]
@@ -173,7 +174,8 @@ impl ColoredString {
         // TODO: BoyScoutRule
         let reset = "\x1B[0m";
         let style = self.compute_style();
-        let matches: Vec<usize> = self.input
+        let matches: Vec<usize> = self
+            .input
             .match_indices(reset)
             .map(|(idx, _)| idx)
             .collect();


### PR DESCRIPTION
This commit:

* implements tty discovery as described in CLICOLOR specifications

* fixes the code to prioritise CLICOLOR_FORCE over NO_COLOR.
The docs said that there is this preference, but in fact
the opposite preference took place before.
(Pattern match had wrong order of lines.)

* removes the prioritization example table because it was wrong,
and it may be harder to read and maintain than the text description above.
(It was wrong on line 5.)

* fix handling of `CLICOLOR_FORCE`, a value of `0` should be
treated identically to unset, not as enforcing the opposite behavior.

* make `ShouldColorize.clicolor` be `bool` instead of `Option<bool>`,
because the optional boolean does not hold any meaning really,
we always practically unwrap it as `.unwrap_or_else(|| true)`.

* fix and add tests in accordance to the specs

fixes GH-54