### PR TITLE
Update winconsole 0.10.0 -> 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+
+- TECH: update winconsole to 0.11.0
 
 # 1.8.0 (April 30, 2019)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ no-color = []
 lazy_static = "1.2.0"
 
 [target.'cfg(windows)'.dependencies]
-winconsole = "0.10.0"
+winconsole = "0.11.0"
 
 [dev_dependencies]
 ansi_term = "^0.9"


### PR DESCRIPTION
We found that we were using old dependencies of `winconsole` and (transitively) `cgmath`, `approx`, `rand`, `num-traits` in our applications due to this dependency in `colored` so updated it here.

Would be great to release a 1.8.1 with this!