### PR TITLE
build: Add Dockerfile and add docker instructions to README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust:latest
+
+ENV SRC_DIR /src
+RUN mkdir $SRC_DIR
+WORKDIR $SRC_DIR
+VOLUME $SRC_DIR
+
+CMD ["/bin/bash"]
+

--- a/README.md
+++ b/README.md
@@ -117,6 +117,25 @@ dumb_terminal = ["colored/no-color"]
 You can use have even finer control by using the
 `colored::control::set_override` method.
 
+## Build with Docker
+
+### Install Docker
+
+Use the install instructions located [here](https://docs.docker.com/v17.12/install/)
+
+### Build the Docker image
+
+```docker build -t colored_image .```
+
+### Build the library
+
+```docker run --rm -it -v "$PWD":/src -u `id -u`:`id -g` colored_image /bin/bash -c "cargo build"```
+
+### Test the library
+
+```docker run --rm -it -v "$PWD":/src -u `id -u`:`id -g` colored_image /bin/bash -c "cargo test"```
+
+
 ## Todo
 
 - **More tests ?**: We always welcome more tests! Please contribute!


### PR DESCRIPTION
This adds a Dockerfile and updates the README.md file with docker instructions.

This will allow the software to be built/developed in an isolated Docker container.