### PR TITLE
test: Add testing for overriding an old style

### DIFF
--- a/tests/ansi_term_compat.rs
+++ b/tests/ansi_term_compat.rs
@@ -119,3 +119,30 @@ mod compat_complex {
         );
     }
 }
+
+mod compat_overrides {
+    use super::ansi_term;
+    use super::ansi_term::*;
+    use super::colored;
+    use super::colored::*;
+
+    #[test]
+    fn overrides1() {
+        let s = "test string";
+        let ansi = Colour::Red.on(Colour::Black).on(Colour::Blue).paint(s);
+        assert_eq!(
+            ansi.to_string(),
+            s.red().on_blue().to_string()
+        );
+    }
+
+    #[test]
+    fn overrides2() {
+        let s = "test string";
+        let ansi = Colour::Green.on(Colour::Yellow).paint(s);
+        assert_eq!(
+            ansi.to_string(),
+            s.green().on_yellow().green().on_yellow().to_string()
+        );
+    }
+}


### PR DESCRIPTION
This could come up when passing strings around and trying to stylize them in more than one place.

The first test checks that it keeps the newest style and the second test checks that applying the same style doesn't break.