### PR TITLE
Bump dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ no-color = []
 lazy_static = "1.2.0"
 
 [target.'cfg(windows)'.dependencies]
-winconsole = "0.10.0"
+winconsole = "0.11.0"
 
 [dev_dependencies]
 ansi_term = "^0.9"


### PR DESCRIPTION
There's a newer version of winconsole