### PR TITLE
Replace winconsole dependency with winapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+# New Version
+
+- **[BREAKING CHANGE]:** Replace `winconsole` with `winapi`:
+  - Changes `set_virtual_terminal` function signature.
+
 # 1.8.0 (April 30, 2019)
 
 - FEAT: support Windows 10 colors

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,14 @@ no-color = []
 [dependencies]
 lazy_static = "1.2.0"
 
-[target.'cfg(windows)'.dependencies]
-winconsole = "0.10.0"
+[target.'cfg(windows)'.dependencies.winapi]
+version = "0.3"
+default-features = false
+features = [
+    "consoleapi",
+    "processenv",
+    "winbase"
+]
 
 [dev_dependencies]
 ansi_term = "^0.9"

--- a/examples/control.rs
+++ b/examples/control.rs
@@ -1,7 +1,33 @@
 extern crate colored;
 use colored::*;
 
+#[cfg(not(windows))]
 fn main() {
+    both()
+}
+
+#[cfg(windows)]
+fn main() {
+    both();
+
+    // additional control setting using windows set_virtual_terminal
+    colored::control::set_virtual_terminal(true);
+    println!("{}", "stdout: Virtual Terminal is in use".bright_green());
+    colored::control::set_virtual_terminal(false);
+    println!("{}", "stderr: Virtual Terminal is NOT in use, escape chars should be visible".bright_red());
+    colored::control::set_virtual_terminal(true);
+    println!("{}", "stdout: Virtual Terminal is in use AGAIN and should be green!".bright_green());
+    colored::control::set_virtual_terminal(true);
+
+    // again with stderr
+    eprintln!("{}", "stderr: Virtual Terminal is in use".bright_green());
+    colored::control::set_virtual_terminal(false);
+    eprintln!("{}", "stderr: Virtual Terminal is NOT in use, escape chars should be visible".bright_red());
+    colored::control::set_virtual_terminal(true);
+    eprintln!("{}", "stderr: Virtual Terminal is in use AGAIN and should be green!".bright_green());
+}
+
+fn both() {
     // this will be yellow if your environment allow it
     println!("{}", "some warning".yellow());
     // now , this will be always yellow

--- a/src/control.rs
+++ b/src/control.rs
@@ -5,7 +5,12 @@ use std::env;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Sets a flag to the console to use a virtual terminal environment.
-/// This is primarily used for Windows 10 environments which will not correctly colorize the outputs based on ansi escape codes.
+///
+/// This is primarily used for Windows 10 environments which will not correctly colorize
+/// the outputs based on ANSI escape codes.
+///
+/// The returned `Result` is _always_ `Ok(())`, the return type was kept to ensure backwards
+/// compatibility.
 ///
 /// # Notes
 /// > Only available to `Windows` build targets.
@@ -13,14 +18,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// # Example
 /// ```rust
 /// use colored::*;
-/// control::set_virtual_terminal(false);
+/// control::set_virtual_terminal(false).unwrap();
 /// println!("{}", "bright cyan".bright_cyan());	// will print '[96mbright cyan[0m' on windows 10
 ///
-/// control::set_virtual_terminal(true);
+/// control::set_virtual_terminal(true).unwrap();
 /// println!("{}", "bright cyan".bright_cyan());	// will print correctly
 /// ```
 #[cfg(windows)]
-pub fn set_virtual_terminal(use_virtual: bool) {
+pub fn set_virtual_terminal(use_virtual: bool) -> Result<(), ()> {
     use winapi::{
         shared::minwindef::DWORD,
         um::{
@@ -46,6 +51,8 @@ pub fn set_virtual_terminal(use_virtual: bool) {
             _ => 0,
         };
     }
+
+    Ok(())
 }
 
 pub struct ShouldColorize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 #[macro_use]
 extern crate lazy_static;
 #[cfg(windows)]
-extern crate winconsole;
+extern crate winapi;
 
 #[cfg(test)]
 extern crate rspec;


### PR DESCRIPTION
PR that changes the `set_virtual_terminal` function to use the crate `winapi` over `winconsole`.

# Motivation
- Reduce (transitive) dependency count
- Reduce dependency size (fewer `winapi` features)

# Changes
Inspired by @noxabellus comment in #56, uses `winapi` calls to set virtual terminal.
This changes the function signature to return a void rather than a result. **I would like some feedback whether this is considered a _breaking change_ given we are _reducing_ the return type. Does this mean _major_ bump or can we just bump _minor_.**

# Additional Notes
This will effectively negate #60 and #66.
