### PR TITLE
Fix various warnings and issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ rust:
 
 cache: cargo
 
+before_script:
+  - rustup component add clippy
+
+script:
+  - cargo test --verbose
+  - cargo clippy -- -Dwarnings
+
 matrix:
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ rust:
   - beta
   - stable
 
+cache: cargo
+
 matrix:
   allow_failures:
     - rust: nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,7 +347,7 @@ impl ColoredString {
     /// assert_eq!(cstr.is_plain(), true);
     /// ```
     pub fn is_plain(&self) -> bool {
-        (self.bgcolor.is_none() && self.fgcolor.is_none() && self.style == style::CLEAR)
+        self.bgcolor.is_none() && self.fgcolor.is_none() && self.style == style::CLEAR
     }
 
     #[cfg(not(feature = "no-color"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,7 +308,7 @@ impl ColoredString {
     /// assert_eq!(cstr.fgcolor(), None);
     /// ```
     pub fn fgcolor(&self) -> Option<Color> {
-        self.fgcolor.as_ref().map(|x| *x)
+        self.fgcolor.as_ref().copied()
     }
 
     /// Get the current background color applied.
@@ -321,7 +321,7 @@ impl ColoredString {
     /// assert_eq!(cstr.bgcolor(), None);
     /// ```
     pub fn bgcolor(&self) -> Option<Color> {
-        self.bgcolor.as_ref().map(|x| *x)
+        self.bgcolor.as_ref().copied()
     }
 
     /// Get the current [`Style`] which can be check if it contains a [`Styles`].

--- a/src/style.rs
+++ b/src/style.rs
@@ -120,8 +120,8 @@ mod tests {
     use super::*;
 
     mod u8_to_styles_invalid_is_none {
+        use super::super::Styles;
         use super::super::CLEARV;
-        use super::super::{Style, Styles};
 
         #[test]
         fn empty_is_none() {
@@ -174,9 +174,6 @@ mod tests {
     mod styles_combine_complex {
         use super::super::Styles::*;
         use super::super::{Style, Styles};
-        use super::super::{
-            BLINK, BOLD, DIMMED, HIDDEN, ITALIC, REVERSED, STRIKETHROUGH, UNDERLINE,
-        };
 
         fn style_from_multiples(styles: &[Styles]) -> Style {
             let mut res = Style(styles[0].to_u8());

--- a/src/style.rs
+++ b/src/style.rs
@@ -96,7 +96,7 @@ impl Style {
     /// assert_eq!(colored.style().contains(Styles::Italic), true);
     /// assert_eq!(colored.style().contains(Styles::Dimmed), false);
     /// ```
-    pub fn contains(&self, style: Styles) -> bool {
+    pub fn contains(self, style: Styles) -> bool {
         let s = style.to_u8();
         self.0 & s == s
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -284,6 +284,7 @@ mod tests {
         }
     }
 
+    #[test]
     fn test_style_contains() {
         let mut style = Style(Styles::Bold.to_u8());
         style.add(Styles::Italic);


### PR DESCRIPTION
I've listed the details of each fix into its own commit message

Warnings were found by running

`cargo clippy`

and

`cargo test`

rust version 1.43.0

@kurtlawrence  