### PR TITLE
Avoid unnecessary copies if there is nothing to escape

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,7 +408,7 @@ impl ColoredString {
             .match_indices(reset)
             .map(|(idx, _)| idx)
             .collect();
-        if matches.len() == 0 {
+        if matches.is_empty() {
             return self.input.as_str().into()
         }
 


### PR DESCRIPTION
That brings ColoredString down to one allocation, which should also be avoidable at the expense of adding lifetimes.

However, this PR is certainly a step in the right direction.