### PR TITLE
Add edition in ```Cargo.toml``` for future compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "colored"
 description = "The most simple way to add colors in your terminal"
 version = "2.0.0"
+edition = "2021"
 authors = ["Thomas Wickham <mackwic@gmail.com>"]
 license = "MPL-2.0"
 homepage = "https://github.com/mackwic/colored"


### PR DESCRIPTION
In future editions of Rust, some parts of the code may get syntax errors, to avoid it I suggest adding the "2021" edition in ```Cargo.toml```