### PR TITLE
Cows. Cows everywhere.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,13 @@ readme = "README.md"
 keywords = ["color", "string", "term", "ansi_term", "term-painter"]
 
 [features]
+default = ["tty"]
+tty = ["dep:atty"]
 # with this feature, no color will ever be written
 no-color = []
 
 [dependencies]
-atty = "0.2"
+atty = { version = "0.2", optional = true }
 lazy_static = "1"
 
 [target.'cfg(windows)'.dependencies.winapi]

--- a/examples/dynamic_colors.rs
+++ b/examples/dynamic_colors.rs
@@ -3,12 +3,12 @@ use colored::*;
 
 fn main() {
     // the easy way
-    "blue string yo".color("blue");
+    println!("{}", "blue string yo".color("blue"));
 
     // this will default to white
-    "white string".color("zorglub");
+    println!("{}", "white string".color("zorglub"));
 
     // the safer way via a Result
     let color_res = "zorglub".parse(); // <- this returns a Result<Color, ()>
-    "red string".color(color_res.unwrap_or(Color::Red));
+    println!("{}", "red string".color(color_res.unwrap_or(Color::Red)));
 }

--- a/src/control.rs
+++ b/src/control.rs
@@ -103,16 +103,15 @@ impl ShouldColorize {
     /// `CLICOLOR_FORCE` takes highest priority, followed by `NO_COLOR`,
     /// followed by `CLICOLOR` combined with tty check.
     pub fn from_env() -> Self {
-        #[allow(unused_mut)]
-        let mut tty: Option<bool> = None;
+        let tty: bool = if cfg!(feature = "tty") {
+            atty::is(atty::Stream::Stdout)
+        } else {
+            false
+        };
 
-        #[cfg(feature = "tty")]
-        {
-            tty = Some(atty::is(atty::Stream::Stdout));
-        }
         ShouldColorize {
             clicolor: ShouldColorize::normalize_env(env::var("CLICOLOR")).unwrap_or(true)
-                && tty.unwrap_or(false),
+                && tty,
             clicolor_force: ShouldColorize::resolve_clicolor_force(
                 env::var("NO_COLOR"),
                 env::var("CLICOLOR_FORCE"),

--- a/src/control.rs
+++ b/src/control.rs
@@ -103,9 +103,16 @@ impl ShouldColorize {
     /// `CLICOLOR_FORCE` takes highest priority, followed by `NO_COLOR`,
     /// followed by `CLICOLOR` combined with tty check.
     pub fn from_env() -> Self {
+        #[allow(unused_mut)]
+        let mut tty: Option<bool> = None;
+
+        #[cfg(feature = "tty")]
+        {
+            tty = Some(atty::is(atty::Stream::Stdout));
+        }
         ShouldColorize {
-            clicolor: ShouldColorize::normalize_env(env::var("CLICOLOR")).unwrap_or_else(|| true)
-                && atty::is(atty::Stream::Stdout),
+            clicolor: ShouldColorize::normalize_env(env::var("CLICOLOR")).unwrap_or(true)
+                && tty.unwrap_or(false),
             clicolor_force: ShouldColorize::resolve_clicolor_force(
                 env::var("NO_COLOR"),
                 env::var("CLICOLOR_FORCE"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //!
 #![warn(missing_docs)]
 
+#[cfg(feature = "tty")]
 extern crate atty;
 #[macro_use]
 extern crate lazy_static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,8 @@ pub use style::{Style, Styles};
 
 /// A string that may have color and/or style applied to it.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ColoredString {
-    input: Cow<'static, str>,
+pub struct ColoredString<'a> {
+    input: Cow<'a, str>,
     fgcolor: Option<Color>,
     bgcolor: Option<Color>,
     style: style::Style,
@@ -64,123 +64,123 @@ pub struct ColoredString {
 /// You can use `colored` effectively simply by importing this trait
 /// and then using its methods on `String` and `&str`.
 #[allow(missing_docs)]
-pub trait Colorize {
+pub trait Colorize<'a> {
     // Font Colors
-    fn black(self) -> ColoredString
+    fn black(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::Black)
     }
-    fn red(self) -> ColoredString
+    fn red(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::Red)
     }
-    fn green(self) -> ColoredString
+    fn green(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::Green)
     }
-    fn yellow(self) -> ColoredString
+    fn yellow(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::Yellow)
     }
-    fn blue(self) -> ColoredString
+    fn blue(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::Blue)
     }
-    fn magenta(self) -> ColoredString
+    fn magenta(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::Magenta)
     }
-    fn purple(self) -> ColoredString
+    fn purple(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::Magenta)
     }
-    fn cyan(self) -> ColoredString
+    fn cyan(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::Cyan)
     }
-    fn white(self) -> ColoredString
+    fn white(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::White)
     }
-    fn bright_black(self) -> ColoredString
+    fn bright_black(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::BrightBlack)
     }
-    fn bright_red(self) -> ColoredString
+    fn bright_red(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::BrightRed)
     }
-    fn bright_green(self) -> ColoredString
+    fn bright_green(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::BrightGreen)
     }
-    fn bright_yellow(self) -> ColoredString
+    fn bright_yellow(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::BrightYellow)
     }
-    fn bright_blue(self) -> ColoredString
+    fn bright_blue(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::BrightBlue)
     }
-    fn bright_magenta(self) -> ColoredString
+    fn bright_magenta(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::BrightMagenta)
     }
-    fn bright_purple(self) -> ColoredString
+    fn bright_purple(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::BrightMagenta)
     }
-    fn bright_cyan(self) -> ColoredString
+    fn bright_cyan(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::BrightCyan)
     }
-    fn bright_white(self) -> ColoredString
+    fn bright_white(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::BrightWhite)
     }
-    fn truecolor(self, r: u8, g: u8, b: u8) -> ColoredString
+    fn truecolor(self, r: u8, g: u8, b: u8) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.color(Color::TrueColor { r, g, b })
     }
-    fn custom_color(self, color: CustomColor) -> ColoredString
+    fn custom_color(self, color: CustomColor) -> ColoredString<'a>
     where
         Self: Sized,
     {
@@ -190,123 +190,123 @@ pub trait Colorize {
             b: color.b,
         })
     }
-    fn color<S: Into<Color>>(self, color: S) -> ColoredString;
+    fn color<S: Into<Color>>(self, color: S) -> ColoredString<'a>;
     // Background Colors
-    fn on_black(self) -> ColoredString
+    fn on_black(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::Black)
     }
-    fn on_red(self) -> ColoredString
+    fn on_red(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::Red)
     }
-    fn on_green(self) -> ColoredString
+    fn on_green(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::Green)
     }
-    fn on_yellow(self) -> ColoredString
+    fn on_yellow(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::Yellow)
     }
-    fn on_blue(self) -> ColoredString
+    fn on_blue(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::Blue)
     }
-    fn on_magenta(self) -> ColoredString
+    fn on_magenta(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::Magenta)
     }
-    fn on_purple(self) -> ColoredString
+    fn on_purple(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::Magenta)
     }
-    fn on_cyan(self) -> ColoredString
+    fn on_cyan(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::Cyan)
     }
-    fn on_white(self) -> ColoredString
+    fn on_white(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::White)
     }
-    fn on_bright_black(self) -> ColoredString
+    fn on_bright_black(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::BrightBlack)
     }
-    fn on_bright_red(self) -> ColoredString
+    fn on_bright_red(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::BrightRed)
     }
-    fn on_bright_green(self) -> ColoredString
+    fn on_bright_green(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::BrightGreen)
     }
-    fn on_bright_yellow(self) -> ColoredString
+    fn on_bright_yellow(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::BrightYellow)
     }
-    fn on_bright_blue(self) -> ColoredString
+    fn on_bright_blue(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::BrightBlue)
     }
-    fn on_bright_magenta(self) -> ColoredString
+    fn on_bright_magenta(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::BrightMagenta)
     }
-    fn on_bright_purple(self) -> ColoredString
+    fn on_bright_purple(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::BrightMagenta)
     }
-    fn on_bright_cyan(self) -> ColoredString
+    fn on_bright_cyan(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::BrightCyan)
     }
-    fn on_bright_white(self) -> ColoredString
+    fn on_bright_white(self) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::BrightWhite)
     }
-    fn on_truecolor(self, r: u8, g: u8, b: u8) -> ColoredString
+    fn on_truecolor(self, r: u8, g: u8, b: u8) -> ColoredString<'a>
     where
         Self: Sized,
     {
         self.on_color(Color::TrueColor { r, g, b })
     }
-    fn on_custom_color(self, color: CustomColor) -> ColoredString
+    fn on_custom_color(self, color: CustomColor) -> ColoredString<'a>
     where
         Self: Sized,
     {
@@ -316,25 +316,25 @@ pub trait Colorize {
             b: color.b,
         })
     }
-    fn on_color<S: Into<Color>>(self, color: S) -> ColoredString;
+    fn on_color<S: Into<Color>>(self, color: S) -> ColoredString<'a>;
     // Styles
-    fn clear(self) -> ColoredString;
-    fn normal(self) -> ColoredString;
-    fn bold(self) -> ColoredString;
-    fn dimmed(self) -> ColoredString;
-    fn italic(self) -> ColoredString;
-    fn underline(self) -> ColoredString;
-    fn blink(self) -> ColoredString;
+    fn clear(self) -> ColoredString<'a>;
+    fn normal(self) -> ColoredString<'a>;
+    fn bold(self) -> ColoredString<'a>;
+    fn dimmed(self) -> ColoredString<'a>;
+    fn italic(self) -> ColoredString<'a>;
+    fn underline(self) -> ColoredString<'a>;
+    fn blink(self) -> ColoredString<'a>;
     /// Historical name of `Colorize::reversed`. May be removed in a future version. Please use
     /// `Colorize::reversed` instead
-    fn reverse(self) -> ColoredString;
+    fn reverse(self) -> ColoredString<'a>;
     /// This should be preferred to `Colorize::reverse`.
-    fn reversed(self) -> ColoredString;
-    fn hidden(self) -> ColoredString;
-    fn strikethrough(self) -> ColoredString;
+    fn reversed(self) -> ColoredString<'a>;
+    fn hidden(self) -> ColoredString<'a>;
+    fn strikethrough(self) -> ColoredString<'a>;
 }
 
-impl ColoredString {
+impl<'a> ColoredString<'a> {
     /// Get the current background color applied.
     ///
     /// ```rust
@@ -467,7 +467,7 @@ impl ColoredString {
     }
 }
 
-impl Default for ColoredString {
+impl Default for ColoredString<'static> {
     fn default() -> Self {
         ColoredString {
             input: "".into(),
@@ -478,139 +478,136 @@ impl Default for ColoredString {
     }
 }
 
-impl Deref for ColoredString {
+impl<'a> Deref for ColoredString<'a> {
     type Target = str;
     fn deref(&self) -> &str {
         &self.input
     }
 }
 
-impl<'a> From<&'a str> for ColoredString {
-    fn from(s: &'a str) -> Self {
+impl<'a, T: Into<Cow<'a, str>>> From<T> for ColoredString<'a> {
+    fn from(s: T) -> Self {
         ColoredString {
             // XXX We'd like to avoid this.
-            input: String::from(s).into(),
+            input: s.into(),
             ..ColoredString::default()
         }
     }
 }
 
-impl Colorize for ColoredString {
-    fn color<S: Into<Color>>(mut self, color: S) -> ColoredString {
+impl<'a> Colorize<'a> for ColoredString<'a> {
+    fn color<S: Into<Color>>(mut self, color: S) -> ColoredString<'a> {
         self.fgcolor = Some(color.into());
         self
     }
-    fn on_color<S: Into<Color>>(mut self, color: S) -> ColoredString {
+    fn on_color<S: Into<Color>>(mut self, color: S) -> ColoredString<'a> {
         self.bgcolor = Some(color.into());
         self
     }
 
-    fn clear(self) -> ColoredString {
+    fn clear(self) -> ColoredString<'a> {
         ColoredString {
             input: self.input,
             ..ColoredString::default()
         }
     }
-    fn normal(self) -> ColoredString {
+    fn normal(self) -> ColoredString<'a> {
         self.clear()
     }
-    fn bold(mut self) -> ColoredString {
+    fn bold(mut self) -> ColoredString<'a> {
         self.style.add(style::Styles::Bold);
         self
     }
-    fn dimmed(mut self) -> ColoredString {
+    fn dimmed(mut self) -> ColoredString<'a> {
         self.style.add(style::Styles::Dimmed);
         self
     }
-    fn italic(mut self) -> ColoredString {
+    fn italic(mut self) -> ColoredString<'a> {
         self.style.add(style::Styles::Italic);
         self
     }
-    fn underline(mut self) -> ColoredString {
+    fn underline(mut self) -> ColoredString<'a> {
         self.style.add(style::Styles::Underline);
         self
     }
-    fn blink(mut self) -> ColoredString {
+    fn blink(mut self) -> ColoredString<'a> {
         self.style.add(style::Styles::Blink);
         self
     }
-    fn reverse(self) -> ColoredString {
+    fn reverse(self) -> ColoredString<'a> {
         self.reversed()
     }
-    fn reversed(mut self) -> ColoredString {
+    fn reversed(mut self) -> ColoredString<'a> {
         self.style.add(style::Styles::Reversed);
         self
     }
-    fn hidden(mut self) -> ColoredString {
+    fn hidden(mut self) -> ColoredString<'a> {
         self.style.add(style::Styles::Hidden);
         self
     }
-    fn strikethrough(mut self) -> ColoredString {
+    fn strikethrough(mut self) -> ColoredString<'a> {
         self.style.add(style::Styles::Strikethrough);
         self
     }
 }
 
-impl<'a> Colorize for &'a str {
-    fn color<S: Into<Color>>(self, color: S) -> ColoredString {
+impl<'a, T: Into<Cow<'a, str>>> Colorize<'a> for T {
+    fn color<S: Into<Color>>(self, color: S) -> ColoredString<'a> {
         ColoredString {
             fgcolor: Some(color.into()),
-            // input: self.into(), BOO XXX
-            input: String::from(self).into(),
+            input: self.into(),
             ..ColoredString::default()
         }
     }
 
-    fn on_color<S: Into<Color>>(self, color: S) -> ColoredString {
+    fn on_color<S: Into<Color>>(self, color: S) -> ColoredString<'a> {
         ColoredString {
             bgcolor: Some(color.into()),
-            // input: self.into(),
-            // XXX: Boo
-            input: String::from(self).into(),
+            input: self.into(),
             ..ColoredString::default()
         }
     }
 
-    fn clear(self) -> ColoredString {
+    fn clear(self) -> ColoredString<'a> {
         ColoredString {
-            input: String::from(self).into(),
+            input: self.into(),
             style: style::CLEAR,
             ..ColoredString::default()
         }
     }
-    fn normal(self) -> ColoredString {
+    fn normal(self) -> ColoredString<'a> {
         self.clear()
     }
-    fn bold(self) -> ColoredString {
+    fn bold(self) -> ColoredString<'a> {
         ColoredString::from(self).bold()
     }
-    fn dimmed(self) -> ColoredString {
+    fn dimmed(self) -> ColoredString<'a> {
         ColoredString::from(self).dimmed()
     }
-    fn italic(self) -> ColoredString {
+    fn italic(self) -> ColoredString<'a> {
         ColoredString::from(self).italic()
     }
-    fn underline(self) -> ColoredString {
+    fn underline(self) -> ColoredString<'a> {
         ColoredString::from(self).underline()
     }
-    fn blink(self) -> ColoredString {
+    fn blink(self) -> ColoredString<'a> {
         ColoredString::from(self).blink()
     }
-    fn reverse(self) -> ColoredString {
+    fn reverse(self) -> ColoredString<'a> {
         self.reversed()
     }
-    fn reversed(self) -> ColoredString {
+    fn reversed(self) -> ColoredString<'a> {
         ColoredString::from(self).reversed()
     }
-    fn hidden(self) -> ColoredString {
+    fn hidden(self) -> ColoredString<'a> {
         ColoredString::from(self).hidden()
     }
-    fn strikethrough(self) -> ColoredString {
+    fn strikethrough(self) -> ColoredString<'a> {
         ColoredString::from(self).strikethrough()
     }
 }
 
-impl fmt::Display for ColoredString {
+impl<'a> fmt::Display for ColoredString<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if !self.has_colors() || self.is_plain() {
             return <str as fmt::Display>::fmt(&self.input, f);


### PR DESCRIPTION
Great project. I saw an opportunity to alloc less. This PR changes input from a `String` to a Cow<'a, str> and the implementation for `&'a str` to `Into<Cow<'a, str>>' which will cover `&str` as before and `String` and `Cow`s and makes the necessary changes to support that. No usage change for the end user, just broader support and less allocs.

As an aside, I added print statements to the dynamic_colors example.