### PR TITLE
Allow windows-sys 0.61 to be used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ no-color = []
 
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = ">=0.48,<=0.60"
+version = ">=0.48,<=0.61"
 features = ["Win32_Foundation", "Win32_System_Console"]
 
 [dev-dependencies]


### PR DESCRIPTION
 `windows-sys` 0.61.x consistently uses `raw-dylib` for importing APIs from Windows DLLs. This vastly improves compatibility when using non-MSVC toolchains to build Windows binaries, e.g. `x86_64-pc-windows-gnullvm`.

Would be great if you could release a patch version 3.0.1 containing this change.

CC @kurtlawrence @spenserblack 