### PR TITLE
Add must_use annotation to ColoredString

### DIFF
--- a/examples/dynamic_colors.rs
+++ b/examples/dynamic_colors.rs
@@ -3,12 +3,12 @@ use colored::{Color, Colorize};
 
 fn main() {
     // the easy way
-    "blue string yo".color("blue");
+    let _ = "blue string yo".color("blue");
 
     // this will default to white
-    "white string".color("zorglub");
+    let _ = "white string".color("zorglub");
 
     // the safer way via a Result
     let color_res = "zorglub".parse(); // <- this returns a Result<Color, ()>
-    "red string".color(color_res.unwrap_or(Color::Red));
+    let _ = "red string".color(color_res.unwrap_or(Color::Red));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@ pub use style::{Style, Styles};
 /// Notice how this process preserves the coloring and style.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
+#[must_use]
 pub struct ColoredString {
     /// The plain text that will have color and style applied to it.
     pub input: String,


### PR DESCRIPTION
Creating a ColoredString includes a costly string allocation, so instances should be used.

Closes: #198